### PR TITLE
docs: add per-stack conventions guide for new projects

### DIFF
--- a/docs/conventions/README.md
+++ b/docs/conventions/README.md
@@ -1,0 +1,29 @@
+# kradalby conventions
+
+Starting a new project? Read this file, then the file for your stack.
+
+## Universal rules
+
+- **Reuse over reinvent.** Stop at the first thing that works; promote shared helpers to a shared lib (`kra`), never copy.
+- **Refresh before building.** This guide goes stale. Before starting, check the newest toolchain/language release and its notes, the relevant upstream (nixpkgs & `lib`, stdlib, framework changelogs, project issues/forums), _and_ my freshest repo. Adopt new idioms and helpers; don't cargo-cult this file.
+- **Comments are terse and explain _why_, not _what_.**
+- **Nix-first.** Every repo has a `flake.nix`. Build/test/lint/format are flake outputs, not ad-hoc scripts.
+- **All checks go through [`kradalby/flake-checks`](https://github.com/kradalby/flake-checks).** Extend it, don't fork the pattern. CI just calls the checks. → [nix.md](nix.md)
+- **prek** runs format+lint hooks; `prek run --all-files` before commit. → [git.md](git.md)
+- **Commits: `package: imperative summary`** — lowercase, no period, no Conventional-Commits prefixes. → [git.md](git.md)
+- **Secrets never in git.** Dev: `.envrc` + 1Password `op read`. Prod: ragenix `age.secrets`. → [secrets.md](secrets.md)
+- **No speculative abstraction.** Smallest thing that works; no abstraction for a single caller.
+
+## Per-stack
+
+[Go](go.md) · [Nix](nix.md) · [Git / CI / prek](git.md) · [Secrets](secrets.md)
+· [Web / Frontend](frontend.md) · [Terraform](terraform.md)
+· [Elm](elm.md) · [Python](python.md) · [Swift](swift.md)
+
+## Reference repos (copy from these)
+
+- Go service + everything: **headscale** · small Go lib: **kra**, **nefit-go**
+- ffcli + koanf config: **gigahost-go** · current flake + CI: **wc3ts**, **tsnixcache**, **z2m-homekit**
+- flake-checks itself: **flake-checks**
+- Server-rendered UI: **nefit-homekit/web**, **tasmota-homekit** · frontend-via-nix: **hugin**
+- Machine config / nix patterns: **dotfiles**

--- a/docs/conventions/elm.md
+++ b/docs/conventions/elm.md
@@ -1,0 +1,18 @@
+# Elm
+
+- Elm **0.19.1**; source in `src/`.
+- elm-pages for full-stack/static sites; `elm/browser` for frontend-only widgets.
+- Styling: elm-css (`rtfeldman/elm-css`), or elm-tailwind-modules in elm-pages projects. elm-markdown for content.
+- Formatting: elm-format via treefmt-nix.
+- **Build via nix**, not bare npm: `fetchElmDeps` + a pinned `elm-srcs.nix` registry; node side via `fetchYarnDeps`. (→ [frontend.md](frontend.md))
+- **Test for full coverage:** elm-test on logic, lean on the type system + elm-review. Don't skip tests.
+
+## Copy from
+
+- `hugin` — Elm + parcel + Go embed via nix
+- `aspargesgaarden-elm` — elm-pages site with image-processing derivations
+
+## Stay current
+
+- elm package registry for current package versions; elm-pages releases.
+- Watch for movement in the (slow-moving) Elm ecosystem before adding deps.

--- a/docs/conventions/frontend.md
+++ b/docs/conventions/frontend.md
@@ -1,0 +1,27 @@
+# Web / Frontend
+
+## Default: server-rendered Go
+
+- `kra/web` for the HTTP + Tailscale server (muxes, `/metrics`, `/debug`, graceful shutdown).
+- **`elem-go` for all HTML** — typed builders, never string templates.
+- **htmx** for interactivity (`hx-post`, `hx-target`); **SSE** for live updates (mirror eventbus payloads to `/events`).
+- Inline `<style>`, system fonts, accessible colors, responsive grids. No SPA framework unless genuinely required.
+- Standard endpoints: `/metrics`, `/health`, `/debug/*`, plus domain routes (`/toggle`, `/api/...`).
+
+## Frontend-via-nix (preferred)
+
+Build elm/parcel/tailwind _inside_ the derivation — reproducible, no ad-hoc `npm run`:
+
+- Node deps pinned: `fetchYarnDeps` / `npmDepsHash`. Elm deps: `fetchElmDeps` + `elm-srcs.nix`.
+- Tailwind/parcel compile runs in `buildPhase`/`patchPhase`; output embedded into the Go binary via `//go:embed dist/*`.
+- hugin pattern: `huginDeps` (yarn2nix) → `huginElm` (parcel build → `$out/dist`) → `hugin` (buildGoModule embeds dist).
+
+## Copy from
+
+- `hugin/flake.nix` — Elm/parcel/tailwind built in nix, embedded into Go
+- `nefit-homekit/web/server.go`, `tasmota-homekit/web.go` — elem-go + htmx + SSE dashboards
+
+## Stay current
+
+- htmx and elem-go releases; new attributes/builders before hand-rolling.
+- Check `kra/web` for new server helpers.

--- a/docs/conventions/git.md
+++ b/docs/conventions/git.md
@@ -1,0 +1,39 @@
+# Git, prek, CI, testing
+
+## Commits
+
+- `package: imperative summary` — lowercase, no period, no `feat:`/`chore:`. e.g. `db: scope DestroyUser to target user`.
+- Scopes seen: `ci:`, `nix:`, `deps:`, `test:`, `build:`, or the package/domain.
+- Body only when _why_ isn't obvious. Footer `Updates/Fixes #N`. Generated code committed separately from hand-written changes.
+- Prefer new commits over history rewrites.
+
+## prek (pre-commit, Rust reimpl)
+
+- `prek run --all-files` before commit; CI runs the same with `fetch-depth: 0`. Config is `.pre-commit-config.yaml` (consumed by prek or pre-commit).
+- Builtins: trailing-whitespace, end-of-file-fixer, check-{json,yaml,toml,merge-conflict}, check-added-large-files, detect-private-key, mixed-line-ending.
+- Local hooks (from the devShell), per tsnixcache:
+  - `treefmt --fail-on-change`
+  - `golangci-lint run --new-from-rev=HEAD~1 --fix`
+  - `go test -short -timeout=5m ./...`
+  - `nix build .#checks.<sys>.{build,golangci-lint,formatting}` gated on `flake.nix`/`go.{mod,sum}` changes
+  - `go run ./cmd/vendorhash check` gated on `go.{mod,sum}`/`flakehashes.json`
+- Exclude `^gen/`, `^testdata/`, `result/`, `.direnv/`.
+
+## GitHub Actions (current shape — wc3ts)
+
+- Nix install `NixOS/nix-installer-action`, cache `Mic92/hestia/action`, checkout `actions/checkout` — all pinned to a commit SHA with a trailing `# vN` comment.
+- Concurrency group cancels superseded runs.
+- Each job calls one check: `nix build -L .#checks.<sys>.<name>` (build, gotest, golangci-lint, formatting) + a `nixos-module` eval job for services. No `nix develop` needed in gate jobs.
+- Deps: dependabot (gomod + github-actions, grouped) and/or scheduled flake-lock update PRs.
+
+## Testing workflow
+
+- Unit tests mandatory for features; run via flake checks / apps.
+- `go test` flags through flake-checks: `-race` (opt-in `goRace`), `-skip` (`goSkip`), `-short` in hooks.
+- Golden / `testdata/` for complex output. Heavy integration matrix (SQLite + PostgreSQL, Docker) only where warranted — see headscale.
+
+## Copy from
+
+- `wc3ts` — current CI workflows (hestia + nix-installer, SHA-pinned)
+- `tsnixcache` — `.pre-commit-config.yaml`, `treefmt.toml`
+- `git log --author=kradalby` (e.g. in headscale) — commit voice, your commits only

--- a/docs/conventions/go.md
+++ b/docs/conventions/go.md
@@ -1,0 +1,74 @@
+# Go
+
+## Version & syntax
+
+- Pin the **latest** Go in `go.mod` and the flake (`go 1.26`, `pkgs.go_1_26`). Match across build/lint/test.
+- Use current-Go features: generics, range-over-func / iterators (`iter.Seq`), `slices`/`maps`/`cmp` stdlib, `min`/`max`. Don't hand-roll what the stdlib gives you.
+
+## Layout
+
+- Packages at repo root, named by function (`state/`, `db/`, `web/`, `config/`, `mapper/`).
+- **Never `internal/`, `pkg/`, `pkgs/`** or generic container dirs (generated code excepted). (headscale)
+- `main` packages under `cmd/<name>/`, thin → one `Run()`/`Execute()`; logic lives in packages. (headscale, kra)
+- Generated code in `gen/`, marked `// Code generated …`, lint-excluded.
+
+## Dependencies
+
+stdlib → `tailscale.com/*` → `kra/*` → blessed dep (below) → your own. Stop at the first that works.
+
+| Need                                       | Use                                                                                                                      |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| Networking / mesh / debug                  | `tailscale.com/*` — tsnet, tsweb, envknob, net/netip, util/eventbus                                                      |
+| Shared HTTP+Tailscale server, HTML helpers | `kra/web`, `kra/html`                                                                                                    |
+| Logging                                    | `log/slog` (zerolog only in headscale — tailscale heritage)                                                              |
+| Config                                     | `github.com/knadh/koanf/v2` (env-only light; add `file` provider when a config file exists). `Netflix/go-env` is legacy. |
+| CLI / flags                                | `github.com/peterbourgon/ff/v3/ffcli` — **never cobra**                                                                  |
+| Internal decoupling                        | `tailscale.com/util/eventbus`                                                                                            |
+| All HTML                                   | `github.com/chasefleming/elem-go` + htmx + SSE (server-rendered, no SPA)                                                 |
+| Tests                                      | `testify/require` + `google/go-cmp`                                                                                      |
+| Metrics                                    | `prometheus/client_golang`                                                                                               |
+| Backoff (never `time.Sleep`)               | `cenkalti/backoff/v5`                                                                                                    |
+
+Specifics:
+
+- **ffcli:** root `*ffcli.Command` + `Subcommands`, each a `newXxxCmd()` owning its `flag.FlagSet`; `root.ParseAndRun(ctx, os.Args[1:])`; `signal.NotifyContext` for shutdown. (tsnixcache, gigahost-go)
+- **koanf:** env-only by default (light config, no file needed); add the `file` provider only when a config file exists. `Netflix/go-env` is legacy — don't use for new code.
+- **elem-go** for every HTML surface, never string templates.
+- **slog** constructed once, passed via constructor; no `fmt.Println`, no `log.Fatal`.
+- `net/netip` not `net.IP`; `envknob` for toggles; `errgroup` + `context` threaded top-down (no bare `go`).
+- **Twelve-factor:** config from env, log to stdout, stateless where possible.
+
+## Errors
+
+- Package-scope sentinels: `var ErrX = errors.New(...)`.
+- Wrap once at the source: `fmt.Errorf("doing thing: %w", err)`; callers decide. Test with `errors.Is`/`errors.As`.
+- Constructors return `(*T, error)`, never panic. Optional config via `type Option func(*T) error`. (gigahost-go/client/options.go)
+
+## Tests
+
+- Table-driven; `testify/require` (fail-fast), `google/go-cmp` for diffs.
+- Async: `require.EventuallyWithT`, never `time.Sleep`. Helpers take `testing.TB`, call `t.Helper()`.
+- Test override hooks: `SetXForTesting`. Race detector on by default.
+- Benchmarks in `bench_test.go` per package. (tsnixcache)
+- Run via flake apps (→ [git.md](git.md)), not bespoke scripts.
+
+## Style / lint
+
+- `golangci-lint` via `.golangci.yaml`: **enable all, disable a few** — copy the disable list from headscale (cyclop, funlen, lll, wsl, varnamelen, wrapcheck, mnd, exhaustruct, …). Don't curate from scratch.
+- Formatting via `treefmt.toml`: gofumpt → `goimports -local github.com/kradalby/<repo>` → nixpkgs-fmt. (tsnixcache). Custom forbidigo bans (`time.Sleep`, inline log-field strings).
+- Comments **terse, explain why not what**; package doc comment mandatory; short names in tight scopes.
+
+## Copy from
+
+- `headscale/hscontrol/app.go` — layout, errors, constructors, eventbus wiring
+- `tsnixcache` — freshest full repo: ffcli subcommands, slog, package layout, bench tests
+- `gigahost-go` — ffcli + koanf config, Option pattern (`client/options.go`)
+- `headscale/.golangci.yaml` — enable-all / disable-few lint config
+
+## Stay current
+
+Before building, verify against upstream — don't assume this guide is current:
+
+- Latest Go release + notes (`go.dev/doc/devel/release`, `go.dev/blog`); bump `go.mod`, adopt new stdlib/syntax.
+- Check `golang.org/x/*` and `tailscale.com/*` for a helper before hand-rolling.
+- Search proposals/issues (`github.com/golang/go`) and `r/golang` / golang-nuts for anything non-trivial you'd write custom.

--- a/docs/conventions/nix.md
+++ b/docs/conventions/nix.md
@@ -1,0 +1,86 @@
+# Nix
+
+## flake-checks (the rule)
+
+All checks route through [`kradalby/flake-checks`](https://github.com/kradalby/flake-checks). Extend it; don't hand-roll checks. CI just calls the resulting `checks.*`.
+
+```nix
+inputs.flake-checks.url = "github:kradalby/flake-checks";
+inputs.flake-checks.inputs.nixpkgs.follows = "nixpkgs";   # share cache
+# ...
+let
+  fc = flake-checks.lib;
+  common = {
+    inherit pkgs;
+    root = ./.;
+    pname = "myapp";
+    version = "0.1.0";
+    vendorHash = "sha256-…";
+    goPkg = pkgs.go_1_26;                                  # pin latest Go
+  };
+in {
+  packages.default = fc.goBuild common;
+  formatter        = fc.formatter common;
+  checks = {
+    build         = fc.goBuild common;
+    gotest        = fc.goTest common;
+    golangci-lint = fc.goLint common;
+    formatting    = fc.goFormat common;                    # gofumpt + goimports + nixpkgs-fmt
+  };
+}
+```
+
+- Each check's src is fileset-filtered → unrelated edits hit cache.
+- `goTest` opts: `goRace`, `goSkip`, `goTags`, `testEnv`, `testPackages`, `proxyVendor`.
+
+## Structure
+
+- `flake-utils.lib.eachDefaultSystem`; dependent inputs always `follows = "nixpkgs"`.
+- Expose `overlays.default`, and for services `nixosModules.default`.
+- Flake apps for ergonomics: `nix run .#test` / `.#test-race` / `.#lint` / `.#coverage`. (z2m-homekit)
+
+## vendorHash churn → flakehashes.json
+
+Hashes that change often live in a root `flakehashes.json`, read with
+`builtins.fromJSON (builtins.readFile ./flakehashes.json)` (e.g. `.vendor.sri`). A small
+`cmd/vendorhash` Go tool (`check` / `update`) keeps it in sync with `go.mod`/`go.sum`; prek
+runs `go run ./cmd/vendorhash check`. Decouples noisy hashes from `flake.nix`. (tsnixcache, headscale, sfiber)
+
+`common` extras seen alongside the required keys: `subPackages`, `env = { CGO_ENABLED = "0"; }`,
+and `.overrideAttrs` to attach `meta` (description/homepage/license/mainProgram). (tsnixcache)
+
+## NixOS module
+
+- Options: `services.<name>.{enable,package,user,group,dataDir,environmentFile,environment}`.
+- `config = lib.mkIf cfg.enable { … }`; systemd hardening (DynamicUser, Restart, WorkingDirectory).
+- Generate config files with `pkgs.formats.{yaml,toml}`. Secrets via `environmentFile` / `LoadCredential` (→ [secrets.md](secrets.md)).
+- Split server/client concerns into separate modules; export each + a `default`. (tsnixcache: `module-server.nix` + `module-client.nix`)
+- **Test modules in CI**: a `nix eval` smoke test (z2m-homekit) or full NixOS VM tests in `nix/tests/*.nix` wired as `checks` (tsnixcache).
+
+## devShell
+
+`go_<ver>`, `gopls`, `golangci-lint`, `gofumpt`, `prek`, `gnumake`. `shellHook` may set `CGO_ENABLED=0` for static builds.
+
+## Formatter
+
+`treefmt` (`treefmt.toml`) orchestrates gofumpt + goimports + nixpkgs-fmt; exposed as `formatter = fc.formatter common`. `alejandra` in dotfiles. Pick one nix formatter per repo, stay consistent.
+
+## Containers (when needed)
+
+Prefer nix-built images (`dockerTools.buildLayeredImage`); fall back to a multi-stage `Dockerfile` only when nix can't. Prefer shipping a NixOS module over a container for your own services.
+
+## Copy from
+
+- `tsnixcache` `flake.nix` + `nix/module-{server,client}.nix` + `nix/tests/*.nix` — freshest full example
+- `z2m-homekit/flake.nix` + `z2m-homekit/nix/module.nix` — modern flake + module + CI
+- `kra/flake.nix` — minimal flake-checks wiring
+- `headscale/flake.nix` — full (overlay, module, flakehashes, docker)
+
+## Stay current
+
+Before building, verify against upstream — don't assume this guide is current:
+
+- nixpkgs manual + recent nixpkgs commits/PRs for changed packaging & module conventions (`buildGoModule`, formatters, `lib`).
+- Search `lib` with **noogle** (`noogle.dev`) before writing a helper.
+- Check `flake-checks` for new check helpers; cross-check the freshest repo (`tsnixcache`, `wc3ts`).
+- Mirror current NixOS option conventions from `nixos/modules` in nixpkgs for the service category you're building.

--- a/docs/conventions/python.md
+++ b/docs/conventions/python.md
@@ -1,0 +1,18 @@
+# Python
+
+- **Type everything.** Full annotations on every def, arg, and return; treat missing/`Any` types as errors. Enforce in CI, not just locally.
+- **`pyright` strict** (`typeCheckingMode = "strict"`) — fail the build on type errors.
+- **`ruff`** for lint _and_ format, with the annotation/modernize rule sets on (`ANN`, `UP`, `SIM`, `B`, `I`); no separate isort/black.
+- **`uv`** for environments + packages (not poetry/pip).
+- Target the latest Python (3.12+), line length 100.
+- Nix flake provides the toolchain; `.venv` via `shellHook` + `uv sync`.
+
+## Copy from
+
+- `betteroako` — uv + ruff + pyright strict, nix devShell
+
+## Stay current
+
+- Latest CPython (use newest stable); adopt new typing syntax.
+- ruff & pyright releases — new lint rules and stricter type checks to enable.
+- `uv` releases for workflow changes.

--- a/docs/conventions/secrets.md
+++ b/docs/conventions/secrets.md
@@ -1,0 +1,42 @@
+# Secrets
+
+## Dev: .envrc + 1Password
+
+- direnv with `use flake` (no `--impure` unless required).
+- Pull secrets on shell entry from 1Password — never commit them:
+
+```bash
+use flake
+export GIGAHOST_TOKEN=$(op read "op://Private/gigahost/token")
+export TF_VAR_unifi_password=$(op read "op://Private/unifi.ldn/password")
+```
+
+- Terraform vars use the `TF_VAR_*` prefix (→ [terraform.md](terraform.md)).
+- Non-secret dev config (URLs, ports, debug flags) inline in `.envrc`.
+- `.envrc.local` (gitignored) for per-machine overrides, sourced if present.
+
+## Prod / NixOS: ragenix
+
+- **ragenix** (`age`) for all NixOS secrets — not sops.
+- `secrets/secrets.nix` maps user + host public keys to which `.age` files they may decrypt.
+- Encrypted `secrets/*.age` are committed (ciphertext only).
+- Declare and consume in a module:
+
+```nix
+age.secrets.cloudflare-ddns-token = {
+  file  = ../secrets/cloudflare-ddns-token.age;
+  mode  = "0400";
+  owner = "cloudflare-ddns";
+};
+# then either:
+systemd.services.cloudflare-ddns.environment.CLOUDFLARE_API_TOKEN_FILE =
+  config.age.secrets.cloudflare-ddns-token.path;
+# or, for key=value env files:
+serviceConfig.EnvironmentFile = config.age.secrets.litestream.path;
+```
+
+## Copy from
+
+- `infrastructure/.envrc` — 1Password + TF_VAR + TF_ENCRYPTION
+- `dotfiles/secrets/secrets.nix` — key map
+- `dotfiles/common/litestream.nix` (environmentFile) / `common/ddns.nix` (path) — consumption patterns

--- a/docs/conventions/swift.md
+++ b/docs/conventions/swift.md
@@ -1,0 +1,21 @@
+# Swift
+
+_Small sample (munin, SwiftExif, Logger.swift) — lower confidence than Go/Nix._
+
+- **SwiftPM only** (`Package.swift`, pinned `swift-tools-version`); one public product per package. Minimal deps.
+- **Swift is kept OUT of the flake** — nixpkgs lags upstream Swift. The flake ships only C deps (libvips, libexif, …) + tools; install Swift via swiftly or a toolchain tarball.
+- Format + lint: swift-format + swiftlint, driven by a `Makefile` (`make fmt` / `make lint`). No `.swiftformat`/`.swiftlint` in small libs.
+- Tests: **swift-testing** (`@Test`/`@Suite`) for new code; legacy XCTest only in older repos.
+- Style: `public` explicit on API; value types (`struct`/`enum`) + extensions over class hierarchies; `Sendable`/`Equatable` on public types; `@available(*, deprecated, message:)` for migrations.
+- Errors: throwing functions with a typed `enum` error (Sendable, Equatable).
+- CI: Swift container (linux) + macOS matrix; `swift build && swift test`. (munin also has a legacy Drone pipeline.)
+
+## Copy from
+
+- `munin` — app: Makefile, swiftlint + swift-format, C-deps-only flake, CI matrix
+- `SwiftExif/Sources/SwiftExif/Types.swift` — public struct/enum style, Sendable, doc comments
+
+## Stay current
+
+- Latest Swift release + SwiftPM changes (manifest API, swift-testing).
+- swift-format / swiftlint releases for new rules.

--- a/docs/conventions/terraform.md
+++ b/docs/conventions/terraform.md
@@ -1,0 +1,28 @@
+# Terraform
+
+**Always OpenTofu (`tofu`), never Terraform.**
+
+- **No secrets in the repo.** Inject from 1Password via `.envrc` as `TF_VAR_*` (→ [secrets.md](secrets.md)). Mark variables `sensitive = true`.
+- **Encrypted state.** Set `TF_ENCRYPTION` (env, in `.envrc`) with a `pbkdf2` key whose passphrase comes from `op read`:
+
+```hcl
+key_provider "pbkdf2" "key" {
+  passphrase = "<from op read>"
+}
+method "aes_gcm" "default" { keys = key_provider.pbkdf2.key }
+state  { method = method.aes_gcm.default }
+plan   { method = method.aes_gcm.default }
+```
+
+- One file per concern: `devices.tf`, `networks.tf`, `variables.tf`, `outputs.tf`, `settings.tf`.
+- Prefer community providers over rolling your own; `tofu fmt` (wired into prek). 2-space indent.
+
+## Copy from
+
+- `infrastructure/.envrc` — `TF_ENCRYPTION` block + `TF_VAR_*` from 1Password
+- `infrastructure/tjoda_unifi/` — file-per-concern layout, `sensitive` vars
+
+## Stay current
+
+- Latest OpenTofu release + notes; new state-encryption / language features.
+- Provider registry (`search.opentofu.org`) for the current provider + version before pinning.


### PR DESCRIPTION
A fresh project — or an agent bootstrapping one — should read one terse file per stack, not reverse-engineer conventions from ~40 repos or wade through the old narrative HomeKit-skewed guide.

`docs/conventions/README.md` is the entry point: universal rules plus a blessed-dependency allowlist, linking out to `go`, `nix`, `git`, `secrets`, `frontend`, `terraform`, `elm`, `python`, `swift`. Each section is bullets with the repo to copy from.

Distilled, not invented — `ff/v3/ffcli` over cobra, `koanf/v2` over `go-env`, `elem-go` for all HTML, `flake-checks` for every check, `slog`, ragenix, `op read` for dev secrets. Freshest repos (`tsnixcache@initial`, `z2m-homekit`) win where older ones disagree.

Generated with the help of an AI assistant