### PR TITLE
modules/claude-code: auto-restart instances stuck disconnected

### DIFF
--- a/modules/claude-code/darwin.nix
+++ b/modules/claude-code/darwin.nix
@@ -9,6 +9,8 @@
 
   darwinPath = "${config.home.profileDirectory}/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
 
+  healthcheck = import ./healthcheck.nix {inherit pkgs lib;};
+
   mkLaunchdAgent = name: ic: {
     enable = true;
     config = {
@@ -28,6 +30,25 @@
 in {
   config = lib.mkIf (pkgs.stdenv.isDarwin && enabled != {}) {
     launchd.agents =
-      lib.mapAttrs' (n: ic: lib.nameValuePair "claude-code-${n}" (mkLaunchdAgent n ic)) enabled;
+      (lib.mapAttrs' (n: ic: lib.nameValuePair "claude-code-${n}" (mkLaunchdAgent n ic)) enabled)
+      // {
+        # KeepAlive only restarts on exit. This catches the alive-but-stuck case
+        # (bridge disconnect / lost login). launchctl comes from /usr/bin via
+        # darwinPath; the rest is bundled in the package's runtimeInputs.
+        claude-code-health = {
+          enable = true;
+          config = {
+            ProgramArguments = ["${healthcheck}/bin/claude-code-health"] ++ lib.attrNames enabled;
+            StartInterval = 120;
+            ProcessType = "Background";
+            EnvironmentVariables = {
+              PATH = darwinPath;
+              HOME = config.home.homeDirectory;
+            };
+            StandardOutPath = "${config.home.homeDirectory}/Library/Logs/claude-code-health.log";
+            StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/claude-code-health-error.log";
+          };
+        };
+      };
   };
 }

--- a/modules/claude-code/healthcheck.nix
+++ b/modules/claude-code/healthcheck.nix
@@ -1,0 +1,15 @@
+{
+  pkgs,
+  lib,
+  ...
+}:
+pkgs.writeShellApplication {
+  name = "claude-code-health";
+
+  # launchctl (Darwin) comes from /usr/bin via the unit's PATH, not nixpkgs.
+  runtimeInputs =
+    (with pkgs; [coreutils gnugrep findutils])
+    ++ lib.optional pkgs.stdenv.isLinux pkgs.systemd;
+
+  text = builtins.readFile ./healthcheck.sh;
+}

--- a/modules/claude-code/healthcheck.sh
+++ b/modules/claude-code/healthcheck.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# claude remote-control watchdog.
+#
+# Restart an instance ONLY when it has been stuck disconnected from the
+# claude.ai bridge past THRESHOLD seconds. Healthy, busy, and idle instances are
+# left untouched. Silent self-heal: actions print to stdout, which the unit
+# captures (journal on Linux, log file on macOS). Usage:
+#
+#   healthcheck.sh <instance-name> [<instance-name> ...]
+#   healthcheck.sh --self-test
+#
+# NOTE: this scrapes the reconnect spinner ("Reconnecting ... disconnected
+# <N>[smh]") that `claude remote-control` prints. That string is not a stable
+# API and rides pkgs.master.claude-code, which updates often. The app's own
+# counter resets to 0s on each successful reconnect, so brief flaps stay small;
+# only a genuinely stuck/lost-login instance lets it grow. --self-test parses the
+# canned samples below, so a format drift fails loudly. Upgrade path: a real
+# `claude remote-control status` command, if one ever ships.
+set -euo pipefail
+
+THRESHOLD=300 # seconds disconnected before we restart
+WINDOW=2      # minutes of recent log to consider (freshness)
+OS=$(uname)
+
+# disc_seconds <text> -> echoes the disconnect counter from the text in seconds,
+# or nothing if no reconnect token is present.
+disc_seconds() {
+  local tok n unit
+  tok=$(grep -oE 'disconnected [0-9]+[smh]' <<<"$1" | tail -1) || true
+  [ -n "$tok" ] || return 0
+  n=${tok##disconnected }
+  unit=${n: -1}
+  n=${n%[smh]}
+  case "$unit" in
+    s) echo "$n" ;;
+    m) echo "$((n * 60))" ;;
+    h) echo "$((n * 3600))" ;;
+  esac
+}
+
+# should_restart <log window> -> 0 (restart) / 1 (leave alone). Pure decision
+# logic, exercised by --self-test. We look only at the LAST non-blank line: while
+# disconnected the spinner redraws every ~1-2s, so a stuck instance ends on a
+# reconnect line; one that flapped and recovered ends on normal activity.
+should_restart() {
+  local last secs
+  last=$(printf '%s' "$1" | tr '\r' '\n' | grep -vE '^[[:space:]]*$' | tail -1) || true
+  secs=$(disc_seconds "$last")
+  [ -n "$secs" ] && [ "$secs" -ge "$THRESHOLD" ]
+}
+
+# fetch_window <instance> -> prints the instance's fresh (last WINDOW min) log.
+# Empty output (idle/connected, emitting nothing) correctly means "leave alone".
+fetch_window() {
+  case "$OS" in
+    Linux)
+      journalctl --user -u "claude-code-$1.service" --since "-${WINDOW}min" -o cat 2>/dev/null
+      ;;
+    Darwin)
+      local log="$HOME/Library/Logs/claude-code-$1.log"
+      # No journald timestamps here, so gate on file mtime: an idle instance
+      # isn't writing, so a stale file means "not stuck right now".
+      if [ -f "$log" ] && find "$log" -mmin "-${WINDOW}" 2>/dev/null | grep -q .; then
+        tail -n 50 "$log" 2>/dev/null
+      fi
+      ;;
+  esac
+}
+
+restart_instance() {
+  case "$OS" in
+    Linux) systemctl --user restart "claude-code-$1.service" ;;
+    Darwin) launchctl kickstart -k "gui/$(id -u)/claude-code-$1" ;;
+  esac
+}
+
+main() {
+  local name window
+  for name in "$@"; do
+    window=$(fetch_window "$name")
+    if should_restart "$window"; then
+      echo "claude-code-health: $name stuck disconnected >= ${THRESHOLD}s, restarting"
+      restart_instance "$name" || echo "claude-code-health: restart of $name FAILED"
+    fi
+  done
+}
+
+self_test() {
+  local fail=0 got
+  check() { # <desc> <yes|no> <log>
+    if should_restart "$3"; then got=yes; else got=no; fi
+    if [ "$got" = "$2" ]; then
+      echo "ok:   $1"
+    else
+      echo "FAIL: $1 (expected $2, got $got)"
+      fail=1
+    fi
+  }
+  check "6-min disconnect -> restart" yes \
+    '·—· Reconnecting · retrying in 602ms · disconnected 6m'
+  check "360s disconnect -> restart" yes \
+    '·/· Reconnecting · retrying in 2.0s · disconnected 360s'
+  check "10s flap -> leave alone" no \
+    '·—· Reconnecting · retrying in 602ms · disconnected 10s'
+  check "flap then recovered -> leave alone" no \
+    $'·—· Reconnecting · retrying in 1s · disconnected 48s\n    Capacity: 1/5 · New sessions will be created in the current directory'
+  check "idle / empty -> leave alone" no ""
+  check "normal activity only -> leave alone" no \
+    '    Capacity: 0/5 · New sessions will be created in the current directory'
+  check "just below threshold (299s) -> leave alone" no \
+    '·—· Reconnecting · retrying in 1s · disconnected 299s'
+  [ "$fail" -eq 0 ] && echo "all self-tests passed"
+  return "$fail"
+}
+
+case "${1:-}" in
+  --self-test) self_test ;;
+  "") echo "usage: $0 <instance-name> [...] | --self-test" >&2; exit 2 ;;
+  *) main "$@" ;;
+esac

--- a/modules/claude-code/linux.nix
+++ b/modules/claude-code/linux.nix
@@ -9,6 +9,11 @@
 
   linuxPath = "${config.home.profileDirectory}/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin";
 
+  # Self-contained: bundles journalctl/systemctl plus the text utils it needs,
+  # so the watchdog works regardless of what the login session exports.
+  healthcheck = import ./healthcheck.nix {inherit pkgs lib;};
+  instanceNames = lib.escapeShellArgs (lib.attrNames enabled);
+
   mkSystemdUnit = name: ic: {
     Unit = {
       Description = "claude remote-control: ${name}";
@@ -41,6 +46,27 @@
 in {
   config = lib.mkIf (pkgs.stdenv.isLinux && enabled != {}) {
     systemd.user.services =
-      lib.mapAttrs' (n: ic: lib.nameValuePair "claude-code-${n}" (mkSystemdUnit n ic)) enabled;
+      (lib.mapAttrs' (n: ic: lib.nameValuePair "claude-code-${n}" (mkSystemdUnit n ic)) enabled)
+      // {
+        # Restart=on-failure only catches exits. This catches the alive-but-stuck
+        # case (bridge disconnect / lost login) that otherwise sits there
+        # "failing to schedule" forever.
+        claude-code-health = {
+          Unit.Description = "claude remote-control watchdog";
+          Service = {
+            Type = "oneshot";
+            ExecStart = "${healthcheck}/bin/claude-code-health ${instanceNames}";
+          };
+        };
+      };
+
+    systemd.user.timers.claude-code-health = {
+      Unit.Description = "claude remote-control watchdog timer";
+      Timer = {
+        OnBootSec = "2min";
+        OnUnitActiveSec = "2min";
+      };
+      Install.WantedBy = ["timers.target"];
+    };
   };
 }

--- a/pkgs/scripts/nix-dev-env.sh
+++ b/pkgs/scripts/nix-dev-env.sh
@@ -39,7 +39,7 @@ grep -qF "$SNAP" "$CLAUDE_ENV_FILE" 2>/dev/null \
     # the source under zsh, so PATH (and the dev tools) never apply. One
     # quoted export prepended to $PATH is shell-agnostic (bash/zsh/POSIX)
     # and OS-agnostic.
-    # ponytail: PATH only; widen the jq to other exported vars if a dev
+    # NOTE: PATH only; widen the jq to other exported vars if a dev
     # shell sets env (CGO flags, PKG_CONFIG_PATH) the Bash tool needs.
     if [ "$stale" = 1 ]; then
       nix print-dev-env --json 2>/dev/null \


### PR DESCRIPTION
`claude remote-control` instances on `dev` and `krair` occasionally stop scheduling sessions while the process stays alive — last time after losing login state, recovered only by a restart. `Restart=on-failure` and launchd `KeepAlive` react to process exit, so they never catch this.

A watchdog timer (every 2 min) restarts an instance only when its most recent log line is the bridge reconnect spinner past a threshold. The app's `disconnected <N>` counter resets on each successful reconnect, so transient flaps, busy, and idle instances are left alone. Restart reloads `~/.claude/.credentials.json` from disk, fixing the lost-login case.

Detection scrapes a log string with no stable API behind it; `healthcheck.sh --self-test` guards against format drift. A fully-frozen process that emits nothing has no signal and is out of scope.

> Generated with the help of an AI assistant