### PR TITLE
rnb: add on-demand remote nix builder selector

### DIFF
--- a/common/rnb-builders.nix
+++ b/common/rnb-builders.nix
@@ -1,0 +1,60 @@
+# Builder registry for `rnb` (remote nix builder selector).
+#
+# Same fields as common/buildmachines.nix, plus:
+#   name       - the short name you type: `rnb <name> -- nix build ...`
+#   host       - groups endpoints of one machine so `--auto` picks one
+#   hasRosetta - informational: the box has a local rosetta linux builder
+#
+# Rendered to ~/.config/rnb/builders.json by home/rnb.nix.
+#
+# Add an endpoint: copy a block, set name/hostName/speedFactor. Get the
+# publicHostKey (base64) with:
+#   ssh <host> base64 -w0 /etc/ssh/ssh_host_ed25519_key.pub
+#
+# speedFactor convention (mirrors buildmachines.nix): 4 = LAN, 2 = tailscale.
+[
+  # dev.ldn via LAN (x86_64-linux; aarch64-linux via binfmt on dev.ldn)
+  {
+    name = "dev.ldn";
+    host = "dev.ldn";
+    hostName = "dev.ldn.fap.no";
+    systems = ["x86_64-linux" "aarch64-linux"];
+    sshUser = "root";
+    sshKey = "/Users/kradalby/.ssh/id_ed25519";
+    maxJobs = 4;
+    speedFactor = 4;
+    supportedFeatures = ["big-parallel" "kvm" "nixos-test"];
+    publicHostKey = "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUhOclJpZVZmckN2bnFOYnV4RXIwNmM2RDEvbGhHbEVJdlM4Tk5RaHJtSnQ=";
+    hasRosetta = false;
+  }
+
+  # dev.ldn via Tailscale (works off-LAN, higher latency)
+  {
+    name = "dev-ldn";
+    host = "dev.ldn";
+    hostName = "dev-ldn.dalby.ts.net";
+    systems = ["x86_64-linux" "aarch64-linux"];
+    sshUser = "root";
+    sshKey = "/Users/kradalby/.ssh/id_ed25519";
+    maxJobs = 4;
+    speedFactor = 2;
+    supportedFeatures = ["big-parallel" "kvm" "nixos-test"];
+    publicHostKey = "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUhOclJpZVZmckN2bnFOYnV4RXIwNmM2RDEvbGhHbEVJdlM4Tk5RaHJtSnQ=";
+    hasRosetta = false;
+  }
+
+  # kratail2 via Tailscale (aarch64-darwin; local rosetta VM for linux)
+  {
+    name = "kratail2";
+    host = "kratail2";
+    hostName = "kratail2.dalby.ts.net";
+    systems = ["aarch64-darwin"];
+    sshUser = "kradalby";
+    sshKey = "/Users/kradalby/.ssh/id_ed25519";
+    maxJobs = 8;
+    speedFactor = 2;
+    supportedFeatures = ["big-parallel"];
+    publicHostKey = "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUh3NTFUQ1BmWkxnbm5ZLzc5ZHZGNDdOc0pFZmptNy9oWVdleUxmZ0J2bUE=";
+    hasRosetta = true;
+  }
+]

--- a/home/default.nix
+++ b/home/default.nix
@@ -137,6 +137,11 @@ in {
         experimental-features = nix-command flakes
       '';
 
+      # rnb (remote nix builder) reads its registry from here; single
+      # source of truth is common/rnb-builders.nix.
+      ".config/rnb/builders.json".text =
+        builtins.toJSON (import ../common/rnb-builders.nix);
+
       ".finicky.js" = lib.mkIf pkgs.stdenv.isDarwin {source = ../rc/finicky.js;};
 
       ".vale.ini".text = ''

--- a/machines/dev.ldn/default.nix
+++ b/machines/dev.ldn/default.nix
@@ -47,6 +47,10 @@ in {
 
   boot.tmp.tmpfsSize = "4G";
 
+  # Build aarch64-linux here (qemu emulation) so `rnb dev.ldn` can serve arm
+  # builds; binfmt auto-advertises it via extra-platforms. Slow but handy.
+  boot.binfmt.emulatedSystems = ["aarch64-linux"];
+
   boot.kernel.sysctl = {
     # if you use ipv4, this is all you need
     "net.ipv4.conf.all.forwarding" = true;

--- a/pkgs/home-packages.nix
+++ b/pkgs/home-packages.nix
@@ -191,6 +191,7 @@ in {
         ++ (with pkgs.unstable; [
           tailscale-tools
           ts-preauthkey
+          rnb
           prek
         ]);
     })

--- a/pkgs/overlays/default.nix
+++ b/pkgs/overlays/default.nix
@@ -15,6 +15,8 @@ in
 
     ts-preauthkey = prev.callPackage ./ts-preauthkey {};
 
+    rnb = prev.callPackage ./rnb {};
+
     rustic = prev.callPackage ./rustic.nix {};
 
     rustic-wrapper = prev.callPackage ../rustic-wrapper {};

--- a/pkgs/overlays/rnb/README.md
+++ b/pkgs/overlays/rnb/README.md
@@ -1,0 +1,41 @@
+# rnb — remote nix builder selector
+
+Run a nix command against an on-demand remote builder, chosen by short name.
+It maps a name to a builder spec, injects it into `NIX_CONFIG`
+(`builders = …` + `max-jobs = 0`), and execs the command — so the build runs on
+the remote, not locally. Works the same for `nix build`, `colmena`,
+`darwin-rebuild`, and `nixos-rebuild`.
+
+Requires the calling user to be a nix `trusted-user` (the daemon only honors
+client-supplied `builders`/`max-jobs` from trusted users).
+
+## Usage
+
+```
+rnb dev.ldn -- nix build .#foo            # exec, like env
+rnb -m dev-ldn -- colmena apply           # merge: remote + local builders
+rnb --auto -- darwin-rebuild switch ...   # pick the reachable builder
+rnb --print dev.ldn | source              # fish: set NIX_CONFIG persistently
+eval "$(rnb --print --posix dev.ldn)"     # bash/sh
+rnb --print --clear | source              # reset
+```
+
+- Default replaces builders and forces all builds remote (`max-jobs = 0`).
+- `-m/--merge` keeps existing builders (e.g. a local rosetta VM) and allows
+  local building.
+- `--auto` TCP-probes endpoints and picks the fastest reachable one per host
+  (LAN over tailnet).
+
+## Config
+
+Reads a builder registry JSON from the first of: `--config`, `$RNB_BUILDERS`,
+`$XDG_CONFIG_HOME/rnb/builders.json` (default `~/.config/rnb/builders.json`).
+
+In this repo the file is rendered from `common/rnb-builders.nix` by `home/rnb.nix`.
+Each entry uses the same fields as a nix build machine plus `name`, `host`
+(groups endpoints for `--auto`), and `hasRosetta`.
+
+## Portability
+
+Self-contained, zero external dependencies. To move to its own repo: relocate
+this directory and rename the module path in `go.mod`.

--- a/pkgs/overlays/rnb/builders/builders.go
+++ b/pkgs/overlays/rnb/builders/builders.go
@@ -1,0 +1,219 @@
+// Package builders maps short builder names to nix remote-builder specs and
+// assembles the NIX_CONFIG that offloads builds to them.
+package builders
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Builder is one remote builder endpoint. JSON tags match the shape
+// builtins.toJSON emits from common/rnb-builders.nix.
+type Builder struct {
+	Name              string   `json:"name"`
+	Host              string   `json:"host"` // groups endpoints of one machine for --auto
+	HostName          string   `json:"hostName"`
+	Systems           []string `json:"systems"`
+	SSHUser           string   `json:"sshUser"`
+	SSHKey            string   `json:"sshKey"`
+	MaxJobs           int      `json:"maxJobs"`
+	SpeedFactor       int      `json:"speedFactor"`
+	SupportedFeatures []string `json:"supportedFeatures"`
+	MandatoryFeatures []string `json:"mandatoryFeatures"`
+	PublicHostKey     string   `json:"publicHostKey"`
+	HasRosetta        bool     `json:"hasRosetta"`
+}
+
+// dash is the machines-file sentinel for an unset field.
+const dash = "-"
+
+func strOrDash(v string) string {
+	if v == "" {
+		return dash
+	}
+	return v
+}
+
+func joinOrDash(xs []string) string {
+	if len(xs) == 0 {
+		return dash
+	}
+	return strings.Join(xs, ",")
+}
+
+func numOrDash(n int) string {
+	if n <= 0 {
+		return dash
+	}
+	return strconv.Itoa(n)
+}
+
+// Spec renders the builder as one nix machines-file line, the eight
+// space-separated fields nix's `builders` setting expects:
+//
+//	ssh-ng://user@host systems key maxjobs speed supported mandatory pubkey
+func (b Builder) Spec() string {
+	uri := "ssh-ng://"
+	if b.SSHUser != "" {
+		uri += b.SSHUser + "@"
+	}
+	uri += b.HostName
+	return strings.Join([]string{
+		uri,
+		joinOrDash(b.Systems),
+		strOrDash(b.SSHKey),
+		numOrDash(b.MaxJobs),
+		numOrDash(b.SpeedFactor),
+		joinOrDash(b.SupportedFeatures),
+		joinOrDash(b.MandatoryFeatures),
+		strOrDash(b.PublicHostKey),
+	}, " ")
+}
+
+// Registry is the set of configured builders.
+type Registry []Builder
+
+// Load reads the registry JSON from the first available of: explicit path,
+// $RNB_BUILDERS, then $XDG_CONFIG_HOME/rnb/builders.json (~/.config fallback).
+// It returns the path it used so callers can report it.
+func Load(explicit string) (Registry, string, error) {
+	path := explicit
+	if path == "" {
+		path = os.Getenv("RNB_BUILDERS")
+	}
+	if path == "" {
+		path = filepath.Join(configHome(), "rnb", "builders.json")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, path, err
+	}
+	var r Registry
+	if err := json.Unmarshal(data, &r); err != nil {
+		return nil, path, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return r, path, nil
+}
+
+func configHome() string {
+	if x := os.Getenv("XDG_CONFIG_HOME"); x != "" {
+		return x
+	}
+	return filepath.Join(os.Getenv("HOME"), ".config")
+}
+
+// Names returns every configured builder name, in registry order.
+func (r Registry) Names() []string {
+	out := make([]string, len(r))
+	for i, b := range r {
+		out[i] = b.Name
+	}
+	return out
+}
+
+// Resolve maps names to builders, erroring on the first unknown name.
+func (r Registry) Resolve(names []string) ([]Builder, error) {
+	out := make([]Builder, 0, len(names))
+	for _, n := range names {
+		i := slices.IndexFunc(r, func(b Builder) bool { return b.Name == n })
+		if i < 0 {
+			return nil, fmt.Errorf("unknown builder %q (configured: %s)", n, strings.Join(r.Names(), ", "))
+		}
+		out = append(out, r[i])
+	}
+	return out, nil
+}
+
+// Reachable reports whether host:22 accepts a TCP connection within a short
+// timeout. It is the default probe for Select.
+func Reachable(hostName string) bool {
+	c, err := net.DialTimeout("tcp", net.JoinHostPort(hostName, "22"), 1500*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = c.Close()
+	return true
+}
+
+// Select picks, per Host group, the reachable endpoint with the highest speed
+// factor — preferring LAN over tailnet automatically. probe decides
+// reachability (injected so tests need no sockets). Result is name-sorted.
+func (r Registry) Select(probe func(string) bool) []Builder {
+	best := map[string]Builder{}
+	for _, b := range r {
+		if !probe(b.HostName) {
+			continue
+		}
+		if cur, ok := best[b.Host]; !ok || b.SpeedFactor > cur.SpeedFactor {
+			best[b.Host] = b
+		}
+	}
+	out := make([]Builder, 0, len(best))
+	for _, b := range best {
+		out = append(out, b)
+	}
+	slices.SortFunc(out, func(a, b Builder) int { return strings.Compare(a.Name, b.Name) })
+	return out
+}
+
+// NixConfig builds the NIX_CONFIG body pointing nix at the given builders.
+//
+// Default (merge=false): builders are replaced and max-jobs is forced to 0, so
+// every build goes remote. merge=true keeps existing builders (typically from
+// `nix config show builders`, e.g. the local rosetta VM) and allows local
+// building. base is the inherited $NIX_CONFIG to extend, if any.
+func NixConfig(bs []Builder, merge bool, existing, base string) string {
+	specs := make([]string, 0, len(bs)+1)
+	if merge && existing != "" {
+		specs = append(specs, existing)
+	}
+	for _, b := range bs {
+		specs = append(specs, b.Spec())
+	}
+
+	lines := []string{"builders = " + strings.Join(specs, " ; ")}
+	if !merge {
+		lines = append(lines, "max-jobs = 0")
+	}
+	lines = append(lines, "builders-use-substitutes = true")
+
+	body := strings.Join(lines, "\n")
+	if base != "" {
+		return base + "\n" + body
+	}
+	return body
+}
+
+// Print renders a shell statement setting NIX_CONFIG to value. fish toggles
+// fish syntax (set -gx) vs POSIX (export).
+func Print(value string, fish bool) string {
+	if fish {
+		return "set -gx NIX_CONFIG " + fishQuote(value)
+	}
+	return "export NIX_CONFIG=" + posixQuote(value)
+}
+
+// PrintClear renders the statement that unsets NIX_CONFIG.
+func PrintClear(fish bool) string {
+	if fish {
+		return "set -e NIX_CONFIG"
+	}
+	return "unset NIX_CONFIG"
+}
+
+func fishQuote(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `'`, `\'`)
+	return "'" + s + "'"
+}
+
+func posixQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, `'`, `'\''`) + "'"
+}

--- a/pkgs/overlays/rnb/builders/builders_test.go
+++ b/pkgs/overlays/rnb/builders/builders_test.go
@@ -1,0 +1,184 @@
+package builders
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// devLDN mirrors the proven-working entry from the end-to-end validation.
+var devLDN = Builder{
+	Name:              "dev.ldn",
+	Host:              "dev.ldn",
+	HostName:          "dev.ldn.fap.no",
+	Systems:           []string{"x86_64-linux"},
+	SSHUser:           "root",
+	SSHKey:            "/Users/kradalby/.ssh/id_ed25519",
+	MaxJobs:           4,
+	SpeedFactor:       4,
+	SupportedFeatures: []string{"big-parallel", "kvm", "nixos-test"},
+	PublicHostKey:     "c3NoLWtleQ==",
+}
+
+func TestSpec(t *testing.T) {
+	tests := []struct {
+		name string
+		b    Builder
+		want string
+	}{
+		{
+			name: "proven dev.ldn line",
+			b:    devLDN,
+			want: "ssh-ng://root@dev.ldn.fap.no x86_64-linux /Users/kradalby/.ssh/id_ed25519 4 4 big-parallel,kvm,nixos-test - c3NoLWtleQ==",
+		},
+		{
+			name: "multiple systems comma-joined",
+			b:    Builder{HostName: "h", SSHUser: "root", Systems: []string{"x86_64-linux", "aarch64-linux"}, MaxJobs: 2, SpeedFactor: 1},
+			want: "ssh-ng://root@h x86_64-linux,aarch64-linux - 2 1 - - -",
+		},
+		{
+			name: "no user, empty optionals become dashes",
+			b:    Builder{HostName: "h", Systems: []string{"x86_64-linux"}},
+			want: "ssh-ng://h x86_64-linux - - - - - -",
+		},
+		{
+			name: "mandatory features rendered, pubkey present",
+			b:    Builder{HostName: "h", SSHUser: "u", Systems: []string{"s"}, SupportedFeatures: []string{"kvm"}, MandatoryFeatures: []string{"big-parallel"}, PublicHostKey: "K"},
+			want: "ssh-ng://u@h s - - - kvm big-parallel K",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.b.Spec(); got != tt.want {
+				t.Errorf("Spec()\n got: %q\nwant: %q", got, tt.want)
+			}
+			if n := len(strings.Fields(tt.b.Spec())); n != 8 {
+				t.Errorf("spec must have 8 fields, got %d: %q", n, tt.b.Spec())
+			}
+		})
+	}
+}
+
+func TestNixConfigDefault(t *testing.T) {
+	got := NixConfig([]Builder{devLDN}, false, "", "")
+	want := "builders = " + devLDN.Spec() + "\nmax-jobs = 0\nbuilders-use-substitutes = true"
+	if got != want {
+		t.Errorf("default NixConfig\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestNixConfigMultipleBuildersJoin(t *testing.T) {
+	b2 := Builder{Name: "b2", HostName: "h2", SSHUser: "root", Systems: []string{"x86_64-linux"}}
+	got := NixConfig([]Builder{devLDN, b2}, false, "", "")
+	wantBuilders := "builders = " + devLDN.Spec() + " ; " + b2.Spec()
+	if !strings.HasPrefix(got, wantBuilders) {
+		t.Errorf("builders should be ';'-joined\n got: %q\nwant prefix: %q", got, wantBuilders)
+	}
+}
+
+func TestNixConfigMerge(t *testing.T) {
+	got := NixConfig([]Builder{devLDN}, true, "@/etc/nix/machines", "")
+	if !strings.HasPrefix(got, "builders = @/etc/nix/machines ; "+devLDN.Spec()) {
+		t.Errorf("merge must prepend existing builders, got: %q", got)
+	}
+	if strings.Contains(got, "max-jobs = 0") {
+		t.Errorf("merge must NOT force max-jobs=0 (keeps local building), got: %q", got)
+	}
+	if !strings.Contains(got, "builders-use-substitutes = true") {
+		t.Errorf("merge should still set builders-use-substitutes, got: %q", got)
+	}
+}
+
+func TestNixConfigExtendsBase(t *testing.T) {
+	got := NixConfig([]Builder{devLDN}, false, "", "experimental-features = nix-command flakes")
+	if !strings.HasPrefix(got, "experimental-features = nix-command flakes\nbuilders = ") {
+		t.Errorf("inherited NIX_CONFIG must be preserved as a prefix, got: %q", got)
+	}
+}
+
+func TestPrint(t *testing.T) {
+	val := "builders = x\nmax-jobs = 0"
+	if got, want := Print(val, true), "set -gx NIX_CONFIG '"+val+"'"; got != want {
+		t.Errorf("fish print\n got: %q\nwant: %q", got, want)
+	}
+	if got, want := Print(val, false), "export NIX_CONFIG='"+val+"'"; got != want {
+		t.Errorf("posix print\n got: %q\nwant: %q", got, want)
+	}
+	if got := PrintClear(true); got != "set -e NIX_CONFIG" {
+		t.Errorf("fish clear: %q", got)
+	}
+	if got := PrintClear(false); got != "unset NIX_CONFIG" {
+		t.Errorf("posix clear: %q", got)
+	}
+}
+
+func TestPrintQuotingEscapes(t *testing.T) {
+	// A value containing a single quote must stay a valid single-quoted literal.
+	if got, want := Print("a'b", false), `export NIX_CONFIG='a'\''b'`; got != want {
+		t.Errorf("posix escaping\n got: %q\nwant: %q", got, want)
+	}
+	if got, want := Print(`a'b\c`, true), `set -gx NIX_CONFIG 'a\'b\\c'`; got != want {
+		t.Errorf("fish escaping\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestResolveUnknown(t *testing.T) {
+	r := Registry{devLDN}
+	if _, err := r.Resolve([]string{"dev.ldn"}); err != nil {
+		t.Fatalf("known name should resolve: %v", err)
+	}
+	_, err := r.Resolve([]string{"nope"})
+	if err == nil || !strings.Contains(err.Error(), "unknown builder") {
+		t.Errorf("unknown name should error, got: %v", err)
+	}
+}
+
+func TestSelectPrefersFastestReachablePerHost(t *testing.T) {
+	lan := Builder{Name: "dev.ldn", Host: "dev.ldn", HostName: "lan", SpeedFactor: 4}
+	ts := Builder{Name: "dev-ldn", Host: "dev.ldn", HostName: "ts", SpeedFactor: 2}
+	other := Builder{Name: "kratail2", Host: "kratail2", HostName: "k", SpeedFactor: 5}
+	r := Registry{lan, ts, other}
+
+	// Both dev.ldn endpoints reachable -> pick the faster LAN; kratail2 down -> dropped.
+	got := r.Select(func(h string) bool { return h != "k" })
+	if len(got) != 1 || got[0].Name != "dev.ldn" {
+		t.Fatalf("want only [dev.ldn], got %+v", names(got))
+	}
+
+	// LAN down -> fall back to tailnet endpoint of the same host.
+	got = r.Select(func(h string) bool { return h == "ts" })
+	if len(got) != 1 || got[0].Name != "dev-ldn" {
+		t.Fatalf("want [dev-ldn] fallback, got %+v", names(got))
+	}
+}
+
+// TestJSONRoundTrip pins the shape builtins.toJSON emits from
+// common/rnb-builders.nix so the Nix-rendered config stays decodable.
+func TestJSONRoundTrip(t *testing.T) {
+	raw := `[
+	  {"name":"dev.ldn","host":"dev.ldn","hostName":"dev.ldn.fap.no",
+	   "systems":["x86_64-linux","aarch64-linux"],"sshUser":"root",
+	   "sshKey":"/Users/kradalby/.ssh/id_ed25519","maxJobs":4,"speedFactor":4,
+	   "supportedFeatures":["big-parallel","kvm","nixos-test"],
+	   "publicHostKey":"c3NoLWtleQ==","hasRosetta":false}
+	]`
+	var r Registry
+	if err := json.Unmarshal([]byte(raw), &r); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(r) != 1 {
+		t.Fatalf("want 1 builder, got %d", len(r))
+	}
+	want := "ssh-ng://root@dev.ldn.fap.no x86_64-linux,aarch64-linux /Users/kradalby/.ssh/id_ed25519 4 4 big-parallel,kvm,nixos-test - c3NoLWtleQ=="
+	if got := r[0].Spec(); got != want {
+		t.Errorf("round-trip spec\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func names(bs []Builder) []string {
+	out := make([]string, len(bs))
+	for i, b := range bs {
+		out[i] = b.Name
+	}
+	return out
+}

--- a/pkgs/overlays/rnb/cmd/rnb/main.go
+++ b/pkgs/overlays/rnb/cmd/rnb/main.go
@@ -1,0 +1,154 @@
+// Command rnb selects nix remote builders by short name and either execs a
+// command with NIX_CONFIG set (like env) or prints a shell statement to source.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/kradalby/dotfiles/pkgs/overlays/rnb/builders"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, "rnb: "+err.Error())
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	fs := flag.NewFlagSet("rnb", flag.ContinueOnError)
+	var merge, auto, doPrint, posix, clear bool
+	var config string
+	fs.BoolVar(&merge, "m", false, "")
+	fs.BoolVar(&merge, "merge", false, "add to existing builders and keep local building")
+	fs.BoolVar(&auto, "auto", false, "pick reachable builders automatically (ignores names)")
+	fs.BoolVar(&doPrint, "print", false, "print a shell statement to source instead of exec")
+	fs.BoolVar(&posix, "posix", false, "with --print, emit POSIX export (default: fish)")
+	fs.BoolVar(&clear, "clear", false, "with --print, emit the NIX_CONFIG unset statement")
+	fs.StringVar(&config, "config", "", "path to builders.json (overrides $RNB_BUILDERS/XDG)")
+	fs.Usage = func() { usage(fs, config) }
+
+	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return nil
+		}
+		return err
+	}
+
+	// --print --clear needs neither a registry nor a command.
+	if doPrint && clear {
+		fmt.Println(builders.PrintClear(!posix))
+		return nil
+	}
+
+	names, command := splitArgs(fs.Args())
+
+	reg, path, err := builders.Load(config)
+	if err != nil {
+		return fmt.Errorf("loading builders (%s): %w", path, err)
+	}
+
+	var selected []builders.Builder
+	if auto {
+		if selected = reg.Select(builders.Reachable); len(selected) == 0 {
+			return fmt.Errorf("--auto: no configured builders reachable")
+		}
+	} else {
+		if len(names) == 0 {
+			fs.Usage()
+			return fmt.Errorf("no builder name given")
+		}
+		if selected, err = reg.Resolve(names); err != nil {
+			return err
+		}
+	}
+
+	existing := ""
+	if merge {
+		existing = currentBuilders()
+	}
+	cfg := builders.NixConfig(selected, merge, existing, os.Getenv("NIX_CONFIG"))
+
+	if doPrint {
+		fmt.Println(builders.Print(cfg, !posix))
+		return nil
+	}
+
+	if len(command) == 0 {
+		return fmt.Errorf("no command: use `rnb <name>... -- <cmd>` or --print")
+	}
+	bin, err := exec.LookPath(command[0])
+	if err != nil {
+		return fmt.Errorf("%s: %w", command[0], err)
+	}
+	return syscall.Exec(bin, command, replaceEnv("NIX_CONFIG", cfg))
+}
+
+// splitArgs divides positional args at the first "--": builder names before,
+// the command after.
+func splitArgs(rest []string) (names, command []string) {
+	for i, a := range rest {
+		if a == "--" {
+			return rest[:i], rest[i+1:]
+		}
+	}
+	return rest, nil
+}
+
+// currentBuilders returns nix's effective `builders` setting (e.g. the local
+// rosetta VM as @/etc/nix/machines), for --merge. Best effort.
+func currentBuilders() string {
+	out, err := exec.Command("nix", "config", "show", "builders").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// replaceEnv returns os.Environ() with key forced to val.
+func replaceEnv(key, val string) []string {
+	prefix := key + "="
+	out := make([]string, 0, len(os.Environ())+1)
+	for _, e := range os.Environ() {
+		if !strings.HasPrefix(e, prefix) {
+			out = append(out, e)
+		}
+	}
+	return append(out, key+"="+val)
+}
+
+func usage(fs *flag.FlagSet, config string) {
+	w := fs.Output()
+	fmt.Fprint(w, `rnb — run a nix command against on-demand remote builders
+
+Usage:
+  rnb [flags] <name>... -- <command>...   set NIX_CONFIG and exec command
+  rnb --print [flags] <name>...           print a shell statement to source
+  rnb --print --clear                     print the NIX_CONFIG unset statement
+
+Flags:
+  -m, --merge   add to existing builders and keep local building
+                (default: replace builders, force all builds remote / max-jobs=0)
+      --auto    pick reachable builders automatically (ignores <name>...)
+      --print   print a shell statement instead of exec'ing the command
+      --posix   with --print, emit POSIX 'export' (default: fish 'set -gx')
+      --clear   with --print, emit the NIX_CONFIG unset statement
+      --config  path to builders.json (default: $RNB_BUILDERS or
+                $XDG_CONFIG_HOME/rnb/builders.json)
+
+Examples:
+  rnb dev.ldn -- nix build .#foo
+  rnb -m dev-ldn -- colmena apply
+  rnb --auto -- darwin-rebuild switch --flake .#krair
+  rnb --print dev.ldn | source           # fish: set NIX_CONFIG in this shell
+  eval "$(rnb --print --posix dev.ldn)"  # bash/sh
+`)
+	if reg, _, err := builders.Load(config); err == nil && len(reg) > 0 {
+		fmt.Fprintln(w, "\nConfigured builders: "+strings.Join(reg.Names(), ", "))
+	}
+}

--- a/pkgs/overlays/rnb/default.nix
+++ b/pkgs/overlays/rnb/default.nix
@@ -1,0 +1,18 @@
+{
+  buildGoModule,
+  go_1_26,
+}:
+(buildGoModule.override {go = go_1_26;}) {
+  pname = "rnb";
+  version = "unstable";
+
+  src = ./.;
+  vendorHash = null; # stdlib only, no external deps
+
+  env.CGO_ENABLED = 0;
+
+  meta = {
+    description = "Select on-demand nix remote builders by short name (NIX_CONFIG injector)";
+    mainProgram = "rnb";
+  };
+}

--- a/pkgs/overlays/rnb/go.mod
+++ b/pkgs/overlays/rnb/go.mod
@@ -1,0 +1,3 @@
+module github.com/kradalby/dotfiles/pkgs/overlays/rnb
+
+go 1.26


### PR DESCRIPTION
Remote builders are hard to use on the spot: the right one depends on which network/tailnet you're on, and there's no quick way to say "build this on `dev.ldn` now".

`rnb <name> -- <cmd>` maps a short name to a builder spec, injects `NIX_CONFIG` (`builders` + `max-jobs=0`), and execs the command — so the build runs on the remote, not locally. Same for `nix build`, `colmena`, `darwin-rebuild`, `nixos-rebuild`. `-m` keeps local/rosetta builders too; `--auto` probes and picks the fastest reachable endpoint; `--print | source` sets it persistently in fish.

Builders live in `common/rnb-builders.nix` (same format as `buildmachines.nix`), rendered once to `~/.config/rnb/builders.json`. The tool is a zero-dependency Go binary, self-contained for a future move to its own repo.

`dev.ldn` gains `aarch64-linux` emulation so it can serve arm builds.

Validated end-to-end: a full `home.ldn` closure (130 derivations) built on `dev.ldn` through the injected config. Relies on the caller being a nix `trusted-user`.

> Generated with the help of an AI assistant