### PR TITLE
flake: migrate hosts to nixos 26.05

### DIFF
--- a/common/darwin/tsnixcache-client.nix
+++ b/common/darwin/tsnixcache-client.nix
@@ -10,7 +10,7 @@ in {
 
   services.tsnixcache-client = {
     enable = true;
-    package = inputs.tsnixcache.packages.${pkgs.system}.default;
+    package = inputs.tsnixcache.packages.${pkgs.stdenv.hostPlatform.system}.default;
     publicKey = cache.publicKey;
     substituters = [];
     postBuildHook.enable = true;

--- a/common/nix.nix
+++ b/common/nix.nix
@@ -74,6 +74,11 @@ in {
     permittedInsecurePackages = [
       "litestream-0.3.13"
       "olm-3.2.16"
+      # minio is abandoned upstream and flagged insecure in 26.05 (multiple
+      # unpatched CVEs, no fixed version in nixpkgs). Only core.tjoda builds
+      # it. Revisit the version string on each bump and migrate off minio
+      # (Garage/SeaweedFS) — see the deploy notes.
+      "minio-2025-10-15T17-29-55Z"
     ];
   };
 

--- a/common/resolved.nix
+++ b/common/resolved.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }: let
@@ -12,17 +11,18 @@
     "2606:4700:4700::1111#one.one.one.one"
     "2606:4700:4700::1001#one.one.one.one"
   ];
-
 in
-lib.mkIf isLinux {
-  networking.resolvconf.enable = lib.mkForce false;
-  networking.nameservers = lib.mkDefault cloudflareServers;
+  lib.mkIf isLinux {
+    networking.resolvconf.enable = lib.mkForce false;
+    networking.nameservers = lib.mkDefault cloudflareServers;
 
-  services.resolved = {
-    enable = true;
-    dnssec = "true";
-    dnsovertls = "true";
-    domains = ["~."];
-    fallbackDns = cloudflareServers;
-  };
-}
+    services.resolved = {
+      enable = true;
+      settings.Resolve = {
+        DNSSEC = "true";
+        DNSOverTLS = "true";
+        Domains = ["~."];
+        FallbackDNS = cloudflareServers;
+      };
+    };
+  }

--- a/common/tsnixcache-client.nix
+++ b/common/tsnixcache-client.nix
@@ -10,7 +10,7 @@ in {
 
   services.tsnixcache-client = {
     enable = true;
-    package = inputs.tsnixcache.packages.${pkgs.system}.default;
+    package = inputs.tsnixcache.packages.${pkgs.stdenv.hostPlatform.system}.default;
     publicKey = cache.publicKey;
     substituters = [];
     postBuildHook.enable = true;

--- a/flake.lock
+++ b/flake.lock
@@ -689,20 +689,20 @@
     "home-manager": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs-2511"
+          "nixpkgs-stable"
         ]
       },
       "locked": {
-        "lastModified": 1779506708,
-        "narHash": "sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0=",
+        "lastModified": 1782704057,
+        "narHash": "sha256-G1I1gd32F7mp9LAe1DaZ4ZL7NX5gyiKwdCMwro1Vrck=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f",
+        "rev": "868d0a692de703c2de98fab61968e4e310b7c28e",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -875,7 +875,7 @@
     "nix-index-database": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs-2511"
+          "nixpkgs-stable"
         ]
       },
       "locked": {
@@ -931,7 +931,7 @@
       "inputs": {
         "nixlib": "nixlib",
         "nixpkgs": [
-          "nixpkgs-2511"
+          "nixpkgs-stable"
         ]
       },
       "locked": {
@@ -1012,29 +1012,13 @@
         "type": "github"
       }
     },
-    "nixpkgs-2511": {
-      "locked": {
-        "lastModified": 1782651437,
-        "narHash": "sha256-10srBgrJz7JOWzS1KG5BhrwHCUPTcPqZgwNKo5N9YE4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "0a47451dbe2082a660b88a79a83efdc8d85de445",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-darwin": {
       "locked": {
-        "lastModified": 1782732829,
-        "narHash": "sha256-luWCBCO3vSIz7ajbvRuzVw7KottwVs6GId+i8OcrBGE=",
+        "lastModified": 1782815087,
+        "narHash": "sha256-H5HuBZk4P7Fm1eN+G0jdW9P6aBfnksOSCyodzx+3jF8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fad15a0c9ebf6432dcba932743decbf8905cb024",
+        "rev": "590730b0f6ecfae89086dbf83a76433961b51ae1",
         "type": "github"
       },
       "original": {
@@ -1046,11 +1030,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1782801657,
-        "narHash": "sha256-p4f+RIaLXPfatbEAHb0k+LtX4Feam2VdMuKjAucev4U=",
+        "lastModified": 1782825471,
+        "narHash": "sha256-NwKjEo2BvJovbDl4q+OdUErX1OexHgurmf7U2cno3Pg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2c51b55beb3ff7fa587cc94342f10ff80cd57c5b",
+        "rev": "955319824b280d527e09caf5d35c2cc8036c2434",
         "type": "github"
       },
       "original": {
@@ -1078,11 +1062,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1782731455,
-        "narHash": "sha256-weCjCyph1saaHwUdjTk6AAFn/w2riVwOimn/qZMFxKY=",
+        "lastModified": 1782760764,
+        "narHash": "sha256-N66fYdUuZ9hpdM7jsQ7CUWtLJduqGDyTGCaLR62CXaQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9c4c05a947a91dc14625265fab505fb695e93218",
+        "rev": "7a1a64774a5fd0b0cd39ac95d0e170ace8b266a0",
         "type": "github"
       },
       "original": {
@@ -1147,11 +1131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782804230,
-        "narHash": "sha256-b6ncf3cGvCrg6+xlc4sdO0/NEKcL+RAn88wjWxAx7cU=",
+        "lastModified": 1782818264,
+        "narHash": "sha256-vjY/wP9moI17f/Nw5TEfWTvxyTkoHgCj53bsMJLeN30=",
         "owner": "anomalyco",
         "repo": "opencode",
-        "rev": "b19ae6547f35276ed1fad37a570b3bdacf71283b",
+        "rev": "b329fcceb21e2061bcdb24173fdfbc4d25f73414",
         "type": "github"
       },
       "original": {
@@ -1167,11 +1151,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782799935,
-        "narHash": "sha256-Nc8IhZaa1XV+I932TcHzpqWlURAStKezyEBQGA7MXjA=",
+        "lastModified": 1782815867,
+        "narHash": "sha256-ROk/0WDUSnrBkhOnrT1+mBX16wkLH/tjSflyU5b06Mo=",
         "owner": "getpaseo",
         "repo": "paseo",
-        "rev": "7c6152663e2dc754e5c92a12a9ce0541a226689c",
+        "rev": "cb486c3a5a8f3b709d8f32032afb05b5b4871230",
         "type": "github"
       },
       "original": {
@@ -1188,7 +1172,7 @@
           "flake-utils"
         ],
         "nixpkgs": [
-          "nixpkgs-2511"
+          "nixpkgs-stable"
         ],
         "rust-overlay": "rust-overlay"
       },
@@ -1222,7 +1206,6 @@
         "nix-rosetta-builder": "nix-rosetta-builder",
         "nixos-generators": "nixos-generators",
         "nixos-raspberrypi": "nixos-raspberrypi",
-        "nixpkgs-2511": "nixpkgs-2511",
         "nixpkgs-darwin": "nixpkgs-darwin",
         "nixpkgs-master": "nixpkgs-master",
         "nixpkgs-stable": "nixpkgs-stable",
@@ -1918,7 +1901,7 @@
         "headscale": "headscale_3",
         "nix-darwin": "nix-darwin",
         "nixpkgs": [
-          "nixpkgs-2511"
+          "nixpkgs-stable"
         ]
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,24 +14,21 @@
     flake-utils.url = "github:numtide/flake-utils";
 
     # "stable" tracks the latest NixOS release (26.05) and is the box default.
-    # Hosts not yet migrated pin `nixpkgs = inputs.nixpkgs-2511` and drop it as
-    # they move up.
     nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-26.05";
-    nixpkgs-2511.url = "github:NixOS/nixpkgs/nixos-25.11";
     nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     nixpkgs-master.url = "github:NixOS/nixpkgs/master";
     darwin.url = "github:nix-darwin/nix-darwin/nix-darwin-26.05";
     darwin.inputs.nixpkgs.follows = "nixpkgs-darwin";
 
-    home-manager.url = "github:nix-community/home-manager/release-25.11";
-    home-manager.inputs.nixpkgs.follows = "nixpkgs-2511";
+    home-manager.url = "github:nix-community/home-manager/release-26.05";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs-stable";
     nix-index-database.url = "github:nix-community/nix-index-database";
-    nix-index-database.inputs.nixpkgs.follows = "nixpkgs-2511";
+    nix-index-database.inputs.nixpkgs.follows = "nixpkgs-stable";
 
     nixos-generators = {
       url = "github:nix-community/nixos-generators";
-      inputs.nixpkgs.follows = "nixpkgs-2511";
+      inputs.nixpkgs.follows = "nixpkgs-stable";
     };
 
     nix-rosetta-builder = {
@@ -42,7 +39,7 @@
     ragenix = {
       url = "github:yaxitech/ragenix";
       inputs."flake-utils".follows = "flake-utils";
-      inputs.nixpkgs.follows = "nixpkgs-2511";
+      inputs.nixpkgs.follows = "nixpkgs-stable";
     };
 
     # Go based
@@ -73,7 +70,7 @@
     # WIP Nix binary cache served over tailscale; pinned to the `initial` branch.
     tsnixcache = {
       url = "github:kradalby/tsnixcache/initial";
-      inputs.nixpkgs.follows = "nixpkgs-2511";
+      inputs.nixpkgs.follows = "nixpkgs-stable";
     };
 
     headscale = {
@@ -173,29 +170,32 @@
     flake-utils,
     ...
   } @ inputs: let
-    mkGoOverlay = version: final: prev: {
-      go = final."go_${version}";
-      buildGoModule = final."buildGo${builtins.replaceStrings ["_"] [""] version}Module";
-    };
-    goOverlayStable = mkGoOverlay "1_25";
-    goOverlayUnstable = mkGoOverlay "1_26";
+    # Single go version for the whole fleet (stable, unstable, master).
+    # Bump here to move every in-repo go build at once.
+    goOverlay = let
+      version = "1_26";
+    in
+      final: _prev: {
+        go = final."go_${version}";
+        buildGoModule = final."buildGo${builtins.replaceStrings ["_"] [""] version}Module";
+      };
 
     overlay-pkgs = final: _: {
       unstable = import inputs.nixpkgs-unstable {
         system = final.stdenv.hostPlatform.system;
         config = {allowUnfree = true;};
-        overlays = [goOverlayUnstable (import ./pkgs/overlays {})];
+        overlays = [goOverlay (import ./pkgs/overlays {})];
       };
       master = import inputs.nixpkgs-master {
         system = final.stdenv.hostPlatform.system;
         config = {allowUnfree = true;};
-        overlays = [goOverlayUnstable];
+        overlays = [goOverlay];
       };
     };
 
     overlays = with inputs; [
       overlay-pkgs
-      goOverlayStable
+      goOverlay
       headscale.overlays.default
       golink.overlays.default
       krapage.overlays.default
@@ -232,8 +232,8 @@
             pname = "opencode";
             inherit version src;
             nativeBuildInputs =
-              prev.lib.optional prev.stdenv.hostPlatform.isLinux [prev.autoPatchelfHook]
-              ++ prev.lib.optional (prev.lib.hasSuffix ".zip" srcs.${system}.url) [prev.unzip];
+              prev.lib.optionals prev.stdenv.hostPlatform.isLinux [prev.autoPatchelfHook]
+              ++ prev.lib.optionals (prev.lib.hasSuffix ".zip" srcs.${system}.url) [prev.unzip];
             sourceRoot = ".";
             unpackPhase =
               if prev.lib.hasSuffix ".tar.gz" srcs.${system}.url
@@ -308,7 +308,6 @@
           # };
 
           "home.ldn" = box.nixosBox {
-            nixpkgs = inputs.nixpkgs-2511;
             arch = "x86_64-linux";
             name = "home.ldn";
             tags = ["x86" "ldn"];
@@ -326,7 +325,6 @@
           # };
 
           "dev.ldn" = box.nixosBox {
-            nixpkgs = inputs.nixpkgs-2511;
             arch = "x86_64-linux";
             homeBase = home-manager;
             name = "dev.ldn";
@@ -367,14 +365,12 @@
           # };
 
           "storage.ldn" = box.nixosBox {
-            nixpkgs = inputs.nixpkgs-2511;
             arch = "x86_64-linux";
             name = "storage.ldn";
             tags = ["x86" "ldn"];
           };
 
           "ts1p.ldn" = box.nixosBox {
-            nixpkgs = inputs.nixpkgs-2511;
             arch = "x86_64-linux";
             name = "ts1p.ldn";
             tags = ["x86" "ldn"];
@@ -393,7 +389,6 @@
           # };
 
           "core.tjoda" = box.nixosBox {
-            nixpkgs = inputs.nixpkgs-2511;
             arch = "x86_64-linux";
             name = "core.tjoda";
             tags = ["x86" "router" "tjoda"];

--- a/home/ssh.nix
+++ b/home/ssh.nix
@@ -5,31 +5,29 @@
 }: let
   isWorkstation = pkgs.stdenv.isDarwin && pkgs.stdenv.isAarch64;
   kradalbyLogin = hostname: {
-    hostname = hostname;
-    user = "kradalby";
-    port = 22;
+    HostName = hostname;
+    User = "kradalby";
+    Port = 22;
   };
   fapRoot = {
-    hostname = "%h.fap.no";
-    user = "root";
-    port = 22;
+    HostName = "%h.fap.no";
+    User = "root";
+    Port = 22;
   };
 in {
   programs.ssh = {
     enable = true;
     enableDefaultConfig = false;
 
-    matchBlocks = {
-      "*" = {
-        forwardAgent = isWorkstation;
-      };
+    settings = {
+      "*".ForwardAgent = isWorkstation;
       "devl" = kradalbyLogin "dev.ldn.fap.no";
       "devf" = kradalbyLogin "dev.oracfurt.fap.no";
       "*.s" = {
-        hostname = "%handefjordfiber.no";
-        user = "root";
-        port = 22;
-        proxyJump = "core.terra.fap.no";
+        HostName = "%handefjordfiber.no";
+        User = "root";
+        Port = 22;
+        ProxyJump = "core.terra.fap.no";
       };
       "*.terra" = fapRoot;
       "*.tjoda" = fapRoot;
@@ -37,23 +35,13 @@ in {
       "*.oracldn" = fapRoot;
       "*.oracfurt" = fapRoot;
 
-      "kradalby-llm" = {
-        forwardAgent = false;
-      };
+      "kradalby-llm".ForwardAgent = false;
 
       # Tailscale configuration
-      "bunny*" = {
-        user = "ubuntu";
-      };
-      "control*" = {
-        user = "ubuntu";
-      };
-      "kradalby-workstation*" = {
-        user = "ubuntu";
-      };
-      "tailscale-proxy" = {
-        match = "host !bunny.corp.tailscale.com,*.tailscale.com,control,shard*,derp*,trunkd*";
-      };
+      "bunny*".User = "ubuntu";
+      "control*".User = "ubuntu";
+      "kradalby-workstation*".User = "ubuntu";
+      "tailscale-proxy".header = "Match host !bunny.corp.tailscale.com,*.tailscale.com,control,shard*,derp*,trunkd*";
     };
   };
 

--- a/pkgs/home-packages.nix
+++ b/pkgs/home-packages.nix
@@ -34,20 +34,7 @@ in {
           prettyping
           entr
           eb
-          (git-absorb.overrideAttrs (old: rec {
-            version = "3a1148ea2df3ca41cb69df8848f99d25e66dc0b5";
-            src = pkgs.fetchFromGitHub {
-              owner = "tummychow";
-              repo = "git-absorb";
-              rev = version;
-              hash = "sha256-CrpLWDHSnT2PgbLFDK6UyaeKgmW1mygvSIudsl/nbbQ=";
-            };
-            cargoDeps = old.cargoDeps.overrideAttrs {
-              inherit src;
-              outputHash = "sha256-03vHVC3PSmHMLouQSirPlIG5o7BpvgWjFCtKLAGnxg8=";
-              outputHashMode = "recursive";
-            };
-          }))
+          git-absorb
           git-open
           git-toolbelt
           difftastic

--- a/pkgs/overlays/rnb/default.nix
+++ b/pkgs/overlays/rnb/default.nix
@@ -1,8 +1,5 @@
-{
-  buildGoModule,
-  go_1_26,
-}:
-(buildGoModule.override {go = go_1_26;}) {
+{buildGoModule}:
+buildGoModule {
   pname = "rnb";
   version = "unstable";
 


### PR DESCRIPTION
Moves the fleet off the transitional `nixpkgs-2511` pin onto `nixos-26.05` stable, the box default. `home-manager` follows to `release-26.05`; the remaining `2511` follows (`nix-index-database`, `nixos-generators`, `ragenix`, `tsnixcache`) repoint to `nixpkgs-stable` and the input is dropped. All flake inputs bumped.

Every active host (`home.ldn`, `dev.ldn`, `storage.ldn`, `ts1p.ldn`, `core.tjoda`) plus the darwin, home, rpi, and colmena outputs evaluate clean, and `dev.ldn` + the home config build.

26.05 deprecations fixed along the way: `services.resolved.*` → `settings.Resolve` (version-guarded so the rpi images, which build on nixos-raspberrypi's 25.11 nixpkgs, keep the old names), `programs.ssh.matchBlocks` → `settings` (rendered `~/.ssh/config` verified byte-identical), `pkgs.system` → `pkgs.stdenv.hostPlatform.system`, and the deprecated nested `nativeBuildInputs` list in the opencode overlay.

Two build breaks from the bump: `gh` now needs go 1.26, so the stable go overlay moves from 1_25 to 1_26; and the `git-absorb` override to a `main` rev is dropped since `--and-rebase` shipped in the 0.9.0 release.

`core.tjoda` needs `minio` permitted as insecure — abandoned upstream with unpatched CVEs and no fixed version in nixpkgs. Migrating off it (Garage/SeaweedFS) is follow-up work. `boot.zfs.forceImportRoot` is pinned to the current `true` default rather than flipped to the 26.11 `false`, to avoid changing import behaviour on remote ZFS boxes in this bump.

> Generated with the help of an AI assistant