### PR TITLE
ac-web: spawn ac sessions from the phone

### DIFF
--- a/machines/dev.ldn/ac-web.nix
+++ b/machines/dev.ldn/ac-web.nix
@@ -1,0 +1,35 @@
+{...}: {
+  # ac-web: auth-less web UI to spawn `ac` coding-agent sessions from the phone.
+  # Binds to the host's tailnet IP (see pkgs/ac-web/main.go), so only the tailnet
+  # can reach it — no auth. Sessions it spawns are ordinary tmux servers in the
+  # shared /tmp, so an interactive `ac` (over ssh) attaches to them later; hence
+  # NO PrivateTmp here (unlike services.claude-code, which isolates its /tmp).
+  home-manager.users.kradalby = {
+    config,
+    pkgs,
+    ...
+  }: {
+    systemd.user.services.ac-web = {
+      Unit = {
+        Description = "ac-web: spawn ac coding-agent sessions from the phone";
+        After = ["network-online.target"];
+        Wants = ["network-online.target"];
+      };
+      Service = {
+        ExecStart = "${pkgs.ac-web}/bin/ac-web";
+        Restart = "always";
+        RestartSec = 15;
+        # KillMode=process so restarting ac-web does not tear down the detached
+        # tmux servers it spawned (they live in this unit's cgroup).
+        KillMode = "process";
+        # Same PATH as modules/claude-code: profile bin has `ac`; system bin has
+        # tmux/git/tailscale that ac and ac-web shell out to.
+        Environment = [
+          "PATH=${config.home.profileDirectory}/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin"
+          "HOME=${config.home.homeDirectory}"
+        ];
+      };
+      Install.WantedBy = ["default.target"];
+    };
+  };
+}

--- a/machines/dev.ldn/default.nix
+++ b/machines/dev.ldn/default.nix
@@ -25,6 +25,7 @@ in {
     ./syncthing.nix
     ./paseo.nix
     ./claude-code.nix
+    ./ac-web.nix
   ];
 
   networking = {

--- a/pkgs/ac-web/default.nix
+++ b/pkgs/ac-web/default.nix
@@ -1,0 +1,18 @@
+{
+  buildGoModule,
+  go_1_26,
+}:
+(buildGoModule.override {go = go_1_26;}) {
+  pname = "ac-web";
+  version = "0.1.0";
+
+  src = ./.;
+  vendorHash = null; # stdlib only, no external deps
+
+  env.CGO_ENABLED = 0;
+
+  meta = {
+    description = "Auth-less Tailscale web UI to spawn `ac` coding-agent sessions from a phone";
+    mainProgram = "ac-web";
+  };
+}

--- a/pkgs/ac-web/go.mod
+++ b/pkgs/ac-web/go.mod
@@ -1,0 +1,3 @@
+module ac-web
+
+go 1.26

--- a/pkgs/ac-web/main.go
+++ b/pkgs/ac-web/main.go
@@ -1,0 +1,288 @@
+// ac-web is a tiny, auth-less web UI for spawning `ac` coding-agent sessions
+// from a phone over Tailscale. It lists repos under ~/git, their worktrees, and
+// running ac sessions, and drives `ac spawn` / `ac rm` to create and clean up
+// detached sessions. Bind it to the tailnet IP so only the tailnet can reach it.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"html/template"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const port = "8846"
+
+var (
+	gitRoot = envOr("GIT_ROOT", filepath.Join(home(), "git"))
+	wtRoot  = envOr("WT_ROOT", filepath.Join(home(), "worktrees"))
+)
+
+func main() {
+	listen := flag.String("listen", "", "address to bind (default: <tailnet-ipv4>:"+port+")")
+	flag.Parse()
+
+	addr := *listen
+	if addr == "" {
+		addr = tailnetAddr()
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", handleIndex)
+	mux.HandleFunc("/spawn", handleSpawn)
+	mux.HandleFunc("/kill", handleKill)
+
+	log.Printf("ac-web listening on http://%s  (git=%s wt=%s)", addr, gitRoot, wtRoot)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}
+
+// --- data ---
+
+type session struct {
+	Server, Repo, Branch, Agent string
+	Attached                    bool
+}
+
+type worktree struct{ Branch string }
+
+type repo struct {
+	Name      string
+	Worktrees []worktree
+}
+
+type pageData struct {
+	Sessions []session
+	Repos    []repo
+}
+
+// repos lists directories under gitRoot that are git repos.
+func repos() []repo {
+	entries, err := os.ReadDir(gitRoot)
+	if err != nil {
+		return nil
+	}
+	var out []repo
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(gitRoot, e.Name(), ".git")); err != nil {
+			continue
+		}
+		out = append(out, repo{Name: e.Name(), Worktrees: worktreesFor(e.Name())})
+	}
+	return out
+}
+
+// worktreesFor returns the branch worktrees for a repo (those living under
+// wtRoot/<repo>/), derived from `git worktree list`. The branch id is the path
+// relative to wtRoot/<repo>, which is exactly what `ac spawn <repo> <branch>`
+// expects. The main worktree (under gitRoot) is excluded.
+func worktreesFor(name string) []worktree {
+	out, err := exec.Command("git", "-C", filepath.Join(gitRoot, name), "worktree", "list", "--porcelain").Output()
+	if err != nil {
+		return nil
+	}
+	prefix := filepath.Join(wtRoot, name) + "/"
+	var res []worktree
+	for line := range strings.SplitSeq(string(out), "\n") {
+		path, ok := strings.CutPrefix(line, "worktree ")
+		if !ok {
+			continue
+		}
+		if branch, under := strings.CutPrefix(path, prefix); under {
+			res = append(res, worktree{Branch: branch})
+		}
+	}
+	return res
+}
+
+// sessions parses `ac ls --porcelain`.
+func sessions() []session {
+	out, err := exec.Command("ac", "ls", "--porcelain").Output()
+	if err != nil {
+		return nil
+	}
+	var res []session
+	for line := range strings.SplitSeq(strings.TrimRight(string(out), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		f := strings.Split(line, "\t")
+		if len(f) < 5 {
+			continue
+		}
+		res = append(res, session{Server: f[0], Repo: f[1], Branch: f[2], Agent: f[3], Attached: f[4] == "1"})
+	}
+	return res
+}
+
+// --- handlers ---
+
+func handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	if err := page.Execute(w, pageData{Sessions: sessions(), Repos: repos()}); err != nil {
+		log.Print(err)
+	}
+}
+
+func handleSpawn(w http.ResponseWriter, r *http.Request) {
+	repoName := r.FormValue("repo")
+	branch := r.FormValue("branch")
+	if err := validateRepo(repoName); err != nil {
+		fail(w, err)
+		return
+	}
+	if err := validateBranch(branch); err != nil {
+		fail(w, err)
+		return
+	}
+	args := []string{"spawn", repoName}
+	if branch != "" {
+		args = append(args, branch)
+	}
+	run(w, r, "ac", args...)
+}
+
+func handleKill(w http.ResponseWriter, r *http.Request) {
+	server := r.FormValue("server")
+	if !serverRe.MatchString(server) {
+		fail(w, fmt.Errorf("invalid server name: %q", server))
+		return
+	}
+	run(w, r, "ac", "rm", server)
+}
+
+// run executes a command and, on success, redirects back to the index; on
+// failure it shows the combined output so the error isn't swallowed.
+func run(w http.ResponseWriter, r *http.Request, name string, args ...string) {
+	out, err := exec.Command(name, args...).CombinedOutput()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("%s %s failed: %v\n\n%s", name, strings.Join(args, " "), err, out), http.StatusInternalServerError)
+		return
+	}
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+func fail(w http.ResponseWriter, err error) { http.Error(w, err.Error(), http.StatusBadRequest) }
+
+// --- validation (the exec trust boundary; args go via argv, never a shell) ---
+
+var (
+	serverRe = regexp.MustCompile(`^ac-[A-Za-z0-9._-]+$`)
+	branchRe = regexp.MustCompile(`^[A-Za-z0-9._/-]+$`)
+)
+
+func validateRepo(name string) error {
+	if name == "" || strings.ContainsAny(name, "/\x00") || strings.Contains(name, "..") {
+		return fmt.Errorf("invalid repo: %q", name)
+	}
+	if _, err := os.Stat(filepath.Join(gitRoot, name, ".git")); err != nil {
+		return fmt.Errorf("not a repo under %s: %q", gitRoot, name)
+	}
+	return nil
+}
+
+// validateBranch permits an empty branch (spawn the main repo). Otherwise the
+// name must look like a git branch: no leading '-', no '..', no whitespace.
+func validateBranch(name string) error {
+	if name == "" {
+		return nil
+	}
+	if strings.HasPrefix(name, "-") || strings.Contains(name, "..") || !branchRe.MatchString(name) {
+		return fmt.Errorf("invalid branch: %q", name)
+	}
+	return nil
+}
+
+// --- helpers ---
+
+func home() string {
+	h, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return h
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+// tailnetAddr resolves the host's Tailscale IPv4, retrying because tailscaled
+// may lag behind network-online at boot.
+func tailnetAddr() string {
+	for range 30 {
+		out, err := exec.Command("tailscale", "ip", "-4").Output()
+		if err == nil {
+			if ip := strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0]); ip != "" {
+				return ip + ":" + port
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	log.Fatal("could not determine tailscale IPv4 (pass -listen to override)")
+	return ""
+}
+
+var page = template.Must(template.New("page").Parse(`<!doctype html>
+<html><head><meta charset=utf-8>
+<meta name=viewport content="width=device-width, initial-scale=1">
+<title>ac-web</title>
+<style>
+ body{font-family:system-ui,sans-serif;margin:0 auto;max-width:40rem;padding:1rem;line-height:1.5}
+ h2{margin:1.5rem 0 .5rem;border-bottom:1px solid #ccc}
+ h3{margin:1rem 0 .25rem}
+ form{display:inline}
+ button{font-size:1rem;padding:.4rem .7rem;margin:.15rem 0}
+ input{font-size:1rem;padding:.4rem}
+ ul{list-style:none;padding:0}
+ li{margin:.3rem 0}
+ .muted{color:#666}
+ .att{color:#0a0}
+</style></head><body>
+<h1>ac-web</h1>
+
+<h2>Running sessions</h2>
+{{if .Sessions}}<ul>
+{{range .Sessions}}<li>
+ <code>{{.Repo}}{{if .Branch}}/{{.Branch}}{{end}}</code> [{{.Agent}}]
+ {{if .Attached}}<span class=att>* attached</span>{{end}}
+ <form method=post action=/kill><input type=hidden name=server value="{{.Server}}"><button>kill</button></form>
+</li>{{end}}
+</ul>{{else}}<p class=muted>none</p>{{end}}
+
+<h2>Repos</h2>
+{{range .Repos}}{{$repo := .Name}}
+<h3>{{.Name}}</h3>
+<form method=post action=/spawn><input type=hidden name=repo value="{{$repo}}"><button>spawn main</button></form>
+{{if .Worktrees}}<ul>
+{{range .Worktrees}}<li>
+ <form method=post action=/spawn>
+  <input type=hidden name=repo value="{{$repo}}">
+  <input type=hidden name=branch value="{{.Branch}}">
+  <button>spawn</button> <code>{{.Branch}}</code>
+ </form>
+</li>{{end}}
+</ul>{{end}}
+<form method=post action=/spawn>
+ <input type=hidden name=repo value="{{$repo}}">
+ <input name=branch placeholder="new branch" required>
+ <button>create + spawn</button>
+</form>
+{{end}}
+</body></html>
+`))

--- a/pkgs/ac-web/main_test.go
+++ b/pkgs/ac-web/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// validateBranch is the exec trust boundary; empty is allowed (main repo),
+// everything shady is rejected.
+func TestValidateBranch(t *testing.T) {
+	ok := []string{"", "foo", "kradalby/3049", "feature/bar-baz", "v1.2.3"}
+	bad := []string{"-rf", "../etc", "a b", "foo;bar", "a..b", "foo$(x)", "back`tick`"}
+	for _, s := range ok {
+		if err := validateBranch(s); err != nil {
+			t.Errorf("validateBranch(%q) = %v, want nil", s, err)
+		}
+	}
+	for _, s := range bad {
+		if err := validateBranch(s); err == nil {
+			t.Errorf("validateBranch(%q) = nil, want error", s)
+		}
+	}
+}
+
+func TestValidateRepo(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "good", ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "notrepo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitRoot = dir
+
+	if err := validateRepo("good"); err != nil {
+		t.Errorf("validateRepo(good) = %v, want nil", err)
+	}
+	for _, s := range []string{"", "notrepo", "missing", "../good", "a/b", "a..b"} {
+		if err := validateRepo(s); err == nil {
+			t.Errorf("validateRepo(%q) = nil, want error", s)
+		}
+	}
+}
+
+func TestServerRe(t *testing.T) {
+	for _, s := range []string{"ac-dotfiles", "ac-headscale-kradalby-3049"} {
+		if !serverRe.MatchString(s) {
+			t.Errorf("serverRe rejected valid %q", s)
+		}
+	}
+	for _, s := range []string{"", "dotfiles", "ac-;rm", "ac- x", "../x"} {
+		if serverRe.MatchString(s) {
+			t.Errorf("serverRe accepted invalid %q", s)
+		}
+	}
+}

--- a/pkgs/overlays/default.nix
+++ b/pkgs/overlays/default.nix
@@ -23,6 +23,8 @@ in
 
     p3-controller = prev.callPackage ../p3-controller {};
 
+    ac-web = prev.callPackage ../ac-web {};
+
     ghostty-tab = prev.callPackage ./ghostty-tab.nix {};
 
     pm-cli = prev.callPackage ./pm-cli.nix {};

--- a/pkgs/scripts/ac.nix
+++ b/pkgs/scripts/ac.nix
@@ -5,6 +5,7 @@ pkgs.writeShellApplication {
   runtimeInputs = with pkgs; [
     tmux
     git
+    jq
     coreutils
     findutils
     gnused

--- a/pkgs/scripts/ac.sh
+++ b/pkgs/scripts/ac.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Main repos live at $GIT_ROOT/<repo>; worktrees at $WT_ROOT/<repo>/<branch>.
 # Mirrors the layout used by wt.fish (default WT_ROOT: ~/worktrees).
-GIT_ROOT="$HOME/git"
+GIT_ROOT="${GIT_ROOT:-$HOME/git}"
 WT_ROOT="${WT_ROOT:-$HOME/worktrees}"
 DEFAULT_AGENT="claude"
 SERVER_PREFIX="ac"
@@ -120,6 +120,30 @@ server_alive() {
 	tmux -L "$server" list-sessions &>/dev/null
 }
 
+ensure_trusted() {
+	# Pre-accept claude's per-directory workspace-trust dialog for $1, so a
+	# freshly created worktree doesn't leave the agent blocked at the trust
+	# prompt (there's no CLI flag for it — it lives in ~/.claude.json). This is
+	# exactly what clicking "Yes, I trust this folder" writes. AC_TRUST=0 skips.
+	local dir="$1" cfg="$HOME/.claude.json" tmp
+	[[ "${AC_TRUST:-1}" == "1" ]] || return 0
+	[[ -f "$cfg" ]] || echo '{}' >"$cfg"
+
+	# Skip (no write) if already trusted — avoids needlessly rewriting a file
+	# claude also writes, shrinking any lost-update race to brand-new dirs only.
+	if [[ "$(jq -r --arg d "$dir" '.projects[$d].hasTrustDialogAccepted // false' "$cfg" 2>/dev/null)" == "true" ]]; then
+		return 0
+	fi
+
+	# Atomic same-dir temp + mv so a reader never sees a partial file.
+	tmp="$(mktemp "${cfg}.XXXXXX")"
+	if jq --arg d "$dir" '.projects[$d].hasTrustDialogAccepted = true' "$cfg" >"$tmp" 2>/dev/null; then
+		mv "$tmp" "$cfg"
+	else
+		rm -f "$tmp"
+	fi
+}
+
 # --- commands ---
 
 create_session() {
@@ -156,8 +180,24 @@ create_session() {
 	tmux -L "$server" set-environment -t work AC_AGENT "$agent"
 	tmux -L "$server" set-environment -t work AC_WORKDIR "$dir"
 
-	# Launch agent in first window (shell survives if agent exits)
-	tmux -L "$server" send-keys -t work:agent "$agent" Enter
+	# Launch agent in first window (shell survives if agent exits). For claude:
+	# run with --dangerously-skip-permissions (no tool prompts), pre-trust the
+	# dir (no trust prompt — a separate gate, pinned explicitly so it survives
+	# claude behaviour drift), and enable Remote Control named
+	# <host>-<repo>-<branch> so the session is also reachable from claude.ai /
+	# the phone. AC_TRUST=0 / AC_REMOTE_CONTROL=0 opt out respectively.
+	local launch="$agent"
+	if [[ "$agent" == "claude" ]]; then
+		ensure_trusted "$dir"
+		launch="$agent --dangerously-skip-permissions"
+		if [[ "${AC_REMOTE_CONTROL:-1}" == "1" ]]; then
+			local rc_name
+			rc_name="$(hostname -s)-${repo}"
+			[[ -n "$branch" ]] && rc_name="${rc_name}-$(sanitize "$branch")"
+			launch="$launch --remote-control $rc_name"
+		fi
+	fi
+	tmux -L "$server" send-keys -t work:agent "$launch" Enter
 
 	# Focus the agent window
 	tmux -L "$server" select-window -t work:agent
@@ -206,6 +246,42 @@ cmd_create_or_attach() {
 		create_session "$server" "$dir" "$agent" "$repo" "$effective_branch"
 		attach_session "$server"
 	fi
+}
+
+cmd_spawn() {
+	# Headless create: like cmd_create_or_attach but never prompts and never
+	# attaches. Used by ac-web to start a detached session from the phone; you
+	# attach later with `ac <repo> [branch]`.
+	local repo="$1" branch="${2:-}" agent="${3:-$DEFAULT_AGENT}"
+
+	# Create the branch worktree if it's missing (no prompt, unlike the
+	# interactive path).
+	if [[ -n "$branch" ]]; then
+		local target_path="$WT_ROOT/$repo/$branch"
+		if [[ ! -d "$target_path" ]]; then
+			local main_wt
+			main_wt=$(find_main_worktree "$repo")
+			create_branch_worktree "$main_wt" "$target_path" "$branch"
+		fi
+	fi
+
+	local dir effective_branch server
+	dir=$(resolve_path "$repo" "$branch")
+	effective_branch=$(resolve_branch "$repo" "$branch")
+	server=$(server_name "$repo" "$effective_branch")
+
+	if server_alive "$server"; then
+		echo "already running: $server"
+		return 0
+	fi
+
+	# Clean up stale socket if present
+	local sock
+	sock="$(sock_dir)/$server"
+	[[ -e "$sock" ]] && rm -f "$sock"
+
+	create_session "$server" "$dir" "$agent" "$repo" "$effective_branch"
+	echo "spawned: $server"
 }
 
 cmd_list() {
@@ -277,6 +353,35 @@ cmd_list() {
 	fi
 }
 
+cmd_list_porcelain() {
+	# Machine-readable listing for ac-web. One live session per line, tab
+	# separated: server<TAB>repo<TAB>branch<TAB>agent<TAB>attached(0|1)
+	local dir
+	dir="$(sock_dir)"
+	[[ -d "$dir" ]] || return 0
+
+	local sockets=()
+	while IFS= read -r -d '' sock; do
+		sockets+=("$sock")
+	done < <(find "$dir" -maxdepth 1 -name "${SERVER_PREFIX}-*" -print0 2>/dev/null | sort -z)
+
+	local sock server ac_repo ac_branch ac_agent num_attached attached
+	for sock in "${sockets[@]}"; do
+		[[ -e "$sock" ]] || continue
+		server=$(basename "$sock")
+		server_alive "$server" || continue
+
+		ac_repo=$(tmux -L "$server" show-environment -t work AC_REPO 2>/dev/null | sed 's/^AC_REPO=//' || echo "")
+		ac_branch=$(tmux -L "$server" show-environment -t work AC_BRANCH 2>/dev/null | sed 's/^AC_BRANCH=//' || echo "")
+		ac_agent=$(tmux -L "$server" show-environment -t work AC_AGENT 2>/dev/null | sed 's/^AC_AGENT=//' || echo "")
+		num_attached=$(tmux -L "$server" list-sessions -t work -F '#{session_attached}' 2>/dev/null | head -1 || echo "0")
+		attached=0
+		[[ "${num_attached:-0}" -gt 0 ]] && attached=1
+
+		printf '%s\t%s\t%s\t%s\t%s\n' "$server" "$ac_repo" "$ac_branch" "$ac_agent" "$attached"
+	done
+}
+
 # Resolve a target (name or index number) to a server name
 resolve_target() {
 	local target="$1"
@@ -340,7 +445,8 @@ Commands:
   (no args)              List all agent sessions
   <repo> [branch]        Create or attach to session
   <number>               Attach to session by index
-  ls                     List all agent sessions
+  ls [--porcelain]       List all agent sessions (--porcelain: tab-separated)
+  spawn <repo> [branch]  Create a detached session without attaching (for ac-web)
   rm <name|number>       Kill a session
   help                   Show this help
 
@@ -372,6 +478,11 @@ Examples:
 Each session opens two tmux windows:
   agent   Coding agent (opencode/claude), launched via send-keys
   term    Plain terminal in the same directory
+
+claude sessions launch with --dangerously-skip-permissions (no tool prompts)
+and Remote Control named <host>-<repo>-<branch>, so they are reachable from
+claude.ai / the phone (AC_REMOTE_CONTROL=0 disables). The working dir is
+pre-trusted so no trust prompt blocks the agent (AC_TRUST=0 disables).
 EOF
 }
 
@@ -379,6 +490,7 @@ EOF
 
 main() {
 	local agent="$DEFAULT_AGENT"
+	local porcelain=0
 	local args=()
 
 	# Parse flags
@@ -390,6 +502,10 @@ main() {
 			;;
 		-c | --claude)
 			agent="claude"
+			shift
+			;;
+		-p | --porcelain)
+			porcelain=1
 			shift
 			;;
 		-h | --help)
@@ -422,7 +538,15 @@ main() {
 	# Subcommands
 	case "$first" in
 	ls | list)
-		cmd_list
+		if [[ "$porcelain" == 1 ]]; then
+			cmd_list_porcelain
+		else
+			cmd_list
+		fi
+		;;
+	spawn)
+		[[ ${#args[@]} -ge 2 ]] || die "usage: ac spawn <repo> [branch]"
+		cmd_spawn "${args[1]}" "${args[2]:-}" "$agent"
 		;;
 	rm | remove | kill)
 		[[ ${#args[@]} -ge 2 ]] || die "usage: ac rm <name|number>"


### PR DESCRIPTION
Two ways to drive agent sessions today: `ac` works well but needs a terminal, and the standalone `claude remote-control` services disconnect constantly. This adds a third path that folds the reliable bits of both.

`ac-web` is an auth-less web UI, bound to the tailnet IP (`http://dev:8846`), to spawn `ac` sessions from the phone. Pick a repo, create or reuse a worktree, tap spawn — later you ssh in and `ac <repo> <branch>` attaches to the session already running.

Every `ac` claude session now launches with Remote Control named `<host>-<repo>-<branch>`, so it's also reachable from claude.ai / the phone. The tmux session persists regardless of the bridge, so a disconnect loses the remote endpoint, not the work. Sessions also run `--dangerously-skip-permissions` and pre-seed claude's workspace-trust entry, so nothing blocks the agent on a fresh worktree.

Runs on `dev.ldn` as a user service, alongside the existing `claude-code` services for now; those can retire once this proves out.

> Generated with the help of an AI assistant