### PR TITLE
claude-code: resume across restarts, graceful shutdown, reliable new sessions

### DIFF
--- a/docs/conventions/nix.md
+++ b/docs/conventions/nix.md
@@ -59,6 +59,22 @@ and `.overrideAttrs` to attach `meta` (description/homepage/license/mainProgram)
 - Split server/client concerns into separate modules; export each + a `default`. (tsnixcache: `module-server.nix` + `module-client.nix`)
 - **Test modules in CI**: a `nix eval` smoke test (z2m-homekit) or full NixOS VM tests in `nix/tests/*.nix` wired as `checks` (tsnixcache).
 
+## Graceful shutdown (always prefer over forced)
+
+Design services to stop **gracefully**; never rely on SIGKILL. The app gets
+SIGTERM (systemd `KillSignal=SIGTERM`, launchd's default unload) plus a generous
+`TimeoutStopSec` to flush state. For `claude remote-control` this is load-bearing:
+a clean SIGTERM lets it *preserve* its environment, so a restart resumes the same
+builder instead of orphaning a fresh one (forced kills filled the claude.ai picker
+with dead duplicates and lost in-flight sessions).
+
+- `KillMode=mixed` over `control-group`: SIGTERM hits the main pid so it
+  orchestrates its own teardown; SIGKILL only mops up stragglers at timeout.
+- Watchdog / restart paths restart gracefully first (`systemctl restart`,
+  `launchctl kill SIGTERM` + `KeepAlive`), escalating to a forced kill
+  (`kickstart -k`, SIGKILL) only after a grace window so a wedged process still
+  recovers. Never reach for `kickstart -k` as the default. (claude-code module)
+
 ## devShell
 
 `go_<ver>`, `gopls`, `golangci-lint`, `gofumpt`, `prek`, `gnumake`. `shellHook` may set `CGO_ENABLED=0` for static builds.

--- a/modules/claude-code/default.nix
+++ b/modules/claude-code/default.nix
@@ -98,13 +98,15 @@ in {
 
         createSessionInDir = lib.mkOption {
           type = lib.types.bool;
-          default = false;
+          default = true;
           description = ''
             Pre-create a session in the working dir on start (claude's
-            `--[no-]create-session-in-dir`). Upstream defaults this on, which
-            makes every (re)start show an empty session in claude.ai/code
-            Recents. Default off here: register the builder without
-            pre-creating a session.
+            `--[no-]create-session-in-dir`). Must stay ON: the anchor session
+            is what gives the environment a stable identity, so a restart
+            *resumes* the same env (one builder per instance in claude.ai/code,
+            sessions restored across new versions). With `--no-create-session-in-dir`
+            every restart mints a fresh env, flooding the picker with dead
+            duplicates and losing in-flight sessions.
           '';
         };
 

--- a/modules/claude-code/default.nix
+++ b/modules/claude-code/default.nix
@@ -43,6 +43,22 @@
     ];
 
   enabled = lib.filterAttrs (_: ic: ic.enable) cfg;
+
+  # Rewrite each builder repo's origin remote to a real URL. Repos cloned via an
+  # insteadOf alias (e.g. `gh:`) store the alias in remote.origin.url; the bridge
+  # registers it verbatim and the API rejects new-session creation with 400 ("The
+  # request was invalid"). `get-url` expands the alias; a real URL is a no-op.
+  # Done at activation, not in ExecStart, so builders restart only on a real
+  # version/config change — never on an incidental git or bash bump.
+  normalizeRemotes =
+    lib.concatMapStringsSep "\n" (ic: let
+      dir = lib.escapeShellArg (resolvePath ic.path);
+    in ''
+      if ${pkgs.git}/bin/git -C ${dir} rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        u="$(${pkgs.git}/bin/git -C ${dir} remote get-url origin 2>/dev/null || true)"
+        [ -n "$u" ] && ${pkgs.git}/bin/git -C ${dir} remote set-url origin "$u" || true
+      fi
+    '') (lib.attrValues enabled);
 in {
   imports = [
     ./linux.nix
@@ -126,7 +142,13 @@ in {
     }));
   };
 
-  config._module.args.claudeCodeLib = {
-    inherit resolvePath mkArgs enabled;
+  config = {
+    _module.args.claudeCodeLib = {
+      inherit resolvePath mkArgs enabled;
+    };
+
+    home.activation = lib.mkIf (enabled != {}) {
+      claudeNormalizeRemotes = lib.hm.dag.entryAfter ["writeBoundary"] normalizeRemotes;
+    };
   };
 }

--- a/modules/claude-code/healthcheck.sh
+++ b/modules/claude-code/healthcheck.sh
@@ -72,6 +72,13 @@ fetch_window() {
 # plist path below must follow (the absent-instance self-test guards the basics).
 darwin_label() { echo "org.nix-community.home.claude-code-$1"; }
 
+# darwin_pid <instance> -> current launchd PID, empty if not running. Used to
+# tell "exited/respawned" from "ignored the signal" during a graceful restart.
+darwin_pid() {
+  launchctl list "$(darwin_label "$1")" 2>/dev/null \
+    | sed -n 's/^[[:space:]]*"PID"[^0-9]*\([0-9]\{1,\}\).*/\1/p'
+}
+
 # is_up <instance> -> 0 if the service is loaded/running, else 1.
 is_up() {
   case "$OS" in
@@ -93,7 +100,7 @@ start_instance() {
       dom="gui/$(id -u)"
       plist="$HOME/Library/LaunchAgents/$label.plist"
       if launchctl list 2>/dev/null | grep -q "$label\$"; then
-        launchctl kickstart -k "$dom/$label"
+        launchctl kickstart "$dom/$label"
       elif [ -f "$plist" ]; then
         launchctl bootstrap "$dom" "$plist"
       else
@@ -103,10 +110,28 @@ start_instance() {
   esac
 }
 
+# Always prefer a graceful restart over a forced kill: SIGTERM lets claude shut
+# down cleanly and PRESERVE its environment, so the restart resumes the same
+# builder instead of orphaning a fresh one (the whole reason the picker filled
+# with dead duplicates). Force-kill only after a grace window, so a genuinely
+# wedged process that ignores SIGTERM still gets recovered.
 restart_instance() {
   case "$OS" in
+    # KillSignal=SIGTERM in the unit -> systemctl restart is already graceful.
     Linux) systemctl --user restart "claude-code-$1.service" ;;
-    Darwin) launchctl kickstart -k "gui/$(id -u)/$(darwin_label "$1")" ;;
+    Darwin)
+      local svc pid0 now _
+      svc="gui/$(id -u)/$(darwin_label "$1")"
+      pid0=$(darwin_pid "$1")
+      launchctl kill SIGTERM "$svc" 2>/dev/null || true
+      # KeepAlive=true respawns on clean exit; wait for the pid to drop or change.
+      for _ in 1 2 3 4 5 6 7 8; do
+        sleep 2
+        now=$(darwin_pid "$1")
+        { [ -z "$now" ] || [ "$now" != "$pid0" ]; } && return 0
+      done
+      launchctl kickstart -k "$svc" # last resort: SIGKILL one that ignored SIGTERM
+      ;;
   esac
 }
 

--- a/modules/claude-code/linux.nix
+++ b/modules/claude-code/linux.nix
@@ -31,6 +31,10 @@
       # come back. StartLimitBurst below caps a genuine crash loop.
       Restart = "always";
       RestartSec = 15;
+      # Graceful over forced: SIGTERM lets claude preserve its environment so a
+      # restart resumes the same builder instead of orphaning a new one. mixed
+      # (SIGTERM to main, SIGKILL to stragglers at timeout) lets the main process
+      # orchestrate its own teardown; TimeoutStopSec gives it room to finish.
       KillSignal = "SIGTERM";
       KillMode = "mixed";
       TimeoutStopSec = 30;


### PR DESCRIPTION
Three fixes so phone-driven `claude remote-control` builders are dependable.

`--no-create-session-in-dir` suppressed the anchor session that gives an environment its stable identity, so every restart minted a fresh env — flooding the picker with dead duplicates and orphaning in-flight sessions. Default it on; a restart now resumes the same env.

The macOS watchdog force-killed with `launchctl kickstart -k` (SIGKILL), skipping claude's preserve-and-resume. Prefer SIGTERM with a forced fallback, matching the Linux units.

New sessions from the phone failed with a 400 ("The request was invalid"). Repos cloned via a `gh:` `insteadOf` alias store that machine-local alias in `remote.origin.url`; the bridge registers it verbatim and the API rejects it on session create. Normalize each builder repo's origin to a real URL at activation, so `ExecStart` — and thus restarts — stay tied to the claude version alone.

> Generated with the help of an AI assistant
