### PR TITLE
ac-web: manage worktrees by activity, branch, and graceful stop

### DIFF
--- a/pkgs/ac-web/main.go
+++ b/pkgs/ac-web/main.go
@@ -14,6 +14,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -38,6 +40,7 @@ func main() {
 	mux.HandleFunc("/", handleIndex)
 	mux.HandleFunc("/spawn", handleSpawn)
 	mux.HandleFunc("/kill", handleKill)
+	mux.HandleFunc("/rmworktree", handleRmWorktree)
 
 	log.Printf("ac-web listening on http://%s  (git=%s wt=%s)", addr, gitRoot, wtRoot)
 	log.Fatal(http.ListenAndServe(addr, mux))
@@ -50,11 +53,15 @@ type session struct {
 	Attached                    bool
 }
 
-type worktree struct{ Branch string }
+type worktree struct {
+	Branch     string
+	LastActive time.Time
+}
 
 type repo struct {
 	Name      string
 	Worktrees []worktree
+	Active    time.Time
 }
 
 type pageData struct {
@@ -62,7 +69,9 @@ type pageData struct {
 	Repos    []repo
 }
 
-// repos lists directories under gitRoot that are git repos.
+// repos lists directories under gitRoot that are git repos, most-recently
+// active first. A repo's activity is the newest of its own HEAD and its
+// worktrees.
 func repos() []repo {
 	entries, err := os.ReadDir(gitRoot)
 	if err != nil {
@@ -76,9 +85,27 @@ func repos() []repo {
 		if _, err := os.Stat(filepath.Join(gitRoot, e.Name(), ".git")); err != nil {
 			continue
 		}
-		out = append(out, repo{Name: e.Name(), Worktrees: worktreesFor(e.Name())})
+		wts := worktreesFor(e.Name())
+		active := lastActive(filepath.Join(gitRoot, e.Name()))
+		if len(wts) > 0 && wts[0].LastActive.After(active) { // wts sorted newest-first
+			active = wts[0].LastActive
+		}
+		out = append(out, repo{Name: e.Name(), Worktrees: wts, Active: active})
 	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Active.After(out[j].Active) })
 	return out
+}
+
+// lastActive returns the committer time of HEAD in dir, or zero on error.
+// ponytail: HEAD commit date is the signal; a worktree freshly branched from an
+// old base sorts old. If that bites, switch to the worktree admin-dir mtime.
+func lastActive(dir string) time.Time {
+	out, err := exec.Command("git", "-C", dir, "log", "-1", "--format=%ct", "HEAD").Output()
+	if err != nil {
+		return time.Time{}
+	}
+	sec, _ := strconv.ParseInt(strings.TrimSpace(string(out)), 10, 64)
+	return time.Unix(sec, 0)
 }
 
 // worktreesFor returns the branch worktrees for a repo (those living under
@@ -98,9 +125,10 @@ func worktreesFor(name string) []worktree {
 			continue
 		}
 		if branch, under := strings.CutPrefix(path, prefix); under {
-			res = append(res, worktree{Branch: branch})
+			res = append(res, worktree{Branch: branch, LastActive: lastActive(path)})
 		}
 	}
+	sort.Slice(res, func(i, j int) bool { return res[i].LastActive.After(res[j].LastActive) })
 	return res
 }
 
@@ -163,6 +191,23 @@ func handleKill(w http.ResponseWriter, r *http.Request) {
 	run(w, r, "ac", "rm", server)
 }
 
+// handleRmWorktree removes a branch worktree (keeping the branch ref).
+// --force --force clears dirty trees and stale agent locks.
+func handleRmWorktree(w http.ResponseWriter, r *http.Request) {
+	repoName := r.FormValue("repo")
+	branch := r.FormValue("branch")
+	if err := validateRepo(repoName); err != nil {
+		fail(w, err)
+		return
+	}
+	if err := validateBranch(branch); err != nil || branch == "" {
+		fail(w, fmt.Errorf("invalid branch: %q", branch))
+		return
+	}
+	run(w, r, "git", "-C", filepath.Join(gitRoot, repoName),
+		"worktree", "remove", "--force", "--force", filepath.Join(wtRoot, repoName, branch))
+}
+
 // run executes a command and, on success, redirects back to the index; on
 // failure it shows the combined output so the error isn't swallowed.
 func run(w http.ResponseWriter, r *http.Request, name string, args ...string) {
@@ -215,6 +260,24 @@ func home() string {
 	return h
 }
 
+// ago renders a coarse "time since" label for the UI: "", "just now", "3h", "5d".
+func ago(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}
+
 func envOr(k, def string) string {
 	if v := os.Getenv(k); v != "" {
 		return v
@@ -238,7 +301,7 @@ func tailnetAddr() string {
 	return ""
 }
 
-var page = template.Must(template.New("page").Parse(`<!doctype html>
+var page = template.Must(template.New("page").Funcs(template.FuncMap{"ago": ago}).Parse(`<!doctype html>
 <html><head><meta charset=utf-8>
 <meta name=viewport content="width=device-width, initial-scale=1">
 <title>ac-web</title>
@@ -261,28 +324,33 @@ var page = template.Must(template.New("page").Parse(`<!doctype html>
 {{range .Sessions}}<li>
  <code>{{.Repo}}{{if .Branch}}/{{.Branch}}{{end}}</code> [{{.Agent}}]
  {{if .Attached}}<span class=att>* attached</span>{{end}}
- <form method=post action=/kill><input type=hidden name=server value="{{.Server}}"><button>kill</button></form>
+ <form method=post action=/kill onsubmit="return confirm('Kill session {{.Server}}?')"><input type=hidden name=server value="{{.Server}}"><button>kill</button></form>
 </li>{{end}}
 </ul>{{else}}<p class=muted>none</p>{{end}}
 
-<h2>Repos</h2>
+<h2>Repos <span class=muted>(newest first)</span></h2>
 {{range .Repos}}{{$repo := .Name}}
-<h3>{{.Name}}</h3>
+<h3>{{.Name}} <span class=muted>{{ago .Active}}</span></h3>
 <form method=post action=/spawn><input type=hidden name=repo value="{{$repo}}"><button>spawn main</button></form>
-{{if .Worktrees}}<ul>
-{{range .Worktrees}}<li>
- <form method=post action=/spawn>
-  <input type=hidden name=repo value="{{$repo}}">
-  <input type=hidden name=branch value="{{.Branch}}">
-  <button>spawn</button> <code>{{.Branch}}</code>
- </form>
-</li>{{end}}
-</ul>{{end}}
 <form method=post action=/spawn>
  <input type=hidden name=repo value="{{$repo}}">
  <input name=branch placeholder="new branch" required>
  <button>create + spawn</button>
 </form>
+{{if .Worktrees}}<ul>
+{{range .Worktrees}}<li>
+ <form method=post action=/spawn>
+  <input type=hidden name=repo value="{{$repo}}">
+  <input type=hidden name=branch value="{{.Branch}}">
+  <button>spawn</button> <code>{{.Branch}}</code> <span class=muted>{{ago .LastActive}}</span>
+ </form>
+ <form method=post action=/rmworktree onsubmit="return confirm('Remove worktree {{$repo}}/{{.Branch}}?')">
+  <input type=hidden name=repo value="{{$repo}}">
+  <input type=hidden name=branch value="{{.Branch}}">
+  <button>rm</button>
+ </form>
+</li>{{end}}
+</ul>{{end}}
 {{end}}
 </body></html>
 `))

--- a/pkgs/ac-web/main.go
+++ b/pkgs/ac-web/main.go
@@ -54,7 +54,8 @@ type session struct {
 }
 
 type worktree struct {
-	Branch     string
+	Branch     string // checked-out branch: the spawn identity, matches `ac`
+	Rel        string // path under wtRoot/<repo>: the delete identity
 	LastActive time.Time
 }
 
@@ -109,25 +110,43 @@ func lastActive(dir string) time.Time {
 }
 
 // worktreesFor returns the branch worktrees for a repo (those living under
-// wtRoot/<repo>/), derived from `git worktree list`. The branch id is the path
-// relative to wtRoot/<repo>, which is exactly what `ac spawn <repo> <branch>`
-// expects. The main worktree (under gitRoot) is excluded.
+// wtRoot/<repo>/), newest-first. Each carries the branch it has checked out —
+// the spawn identity, which `ac spawn <repo> <branch>` resolves the same way
+// the CLI does — and its path relative to wtRoot/<repo>, the unambiguous delete
+// identity (it can differ from the branch name after a rename). The main
+// worktree (under gitRoot) is excluded.
 func worktreesFor(name string) []worktree {
 	out, err := exec.Command("git", "-C", filepath.Join(gitRoot, name), "worktree", "list", "--porcelain").Output()
 	if err != nil {
 		return nil
 	}
 	prefix := filepath.Join(wtRoot, name) + "/"
+
 	var res []worktree
-	for line := range strings.SplitSeq(string(out), "\n") {
-		path, ok := strings.CutPrefix(line, "worktree ")
-		if !ok {
-			continue
+	var path, branch string
+	var under bool
+	commit := func() { // flush the current porcelain block
+		if under {
+			b := branch
+			if b == "" { // detached HEAD: fall back to the dir name
+				b = strings.TrimPrefix(path, prefix)
+			}
+			res = append(res, worktree{Branch: b, Rel: strings.TrimPrefix(path, prefix), LastActive: lastActive(path)})
 		}
-		if branch, under := strings.CutPrefix(path, prefix); under {
-			res = append(res, worktree{Branch: branch, LastActive: lastActive(path)})
+		path, branch, under = "", "", false
+	}
+	for line := range strings.SplitSeq(string(out), "\n") {
+		switch {
+		case strings.HasPrefix(line, "worktree "):
+			commit()
+			path = strings.TrimPrefix(line, "worktree ")
+			under = strings.HasPrefix(path, prefix)
+		case strings.HasPrefix(line, "branch "):
+			branch = strings.TrimPrefix(strings.TrimPrefix(line, "branch "), "refs/heads/")
 		}
 	}
+	commit()
+
 	sort.Slice(res, func(i, j int) bool { return res[i].LastActive.After(res[j].LastActive) })
 	return res
 }
@@ -191,21 +210,23 @@ func handleKill(w http.ResponseWriter, r *http.Request) {
 	run(w, r, "ac", "rm", server)
 }
 
-// handleRmWorktree removes a branch worktree (keeping the branch ref).
-// --force --force clears dirty trees and stale agent locks.
+// handleRmWorktree removes a worktree by its path under wtRoot/<repo> (keeping
+// the branch ref). Removing by path, not by branch name, is what makes this
+// correct when the two differ after a rename. --force --force clears dirty
+// trees and stale agent locks.
 func handleRmWorktree(w http.ResponseWriter, r *http.Request) {
 	repoName := r.FormValue("repo")
-	branch := r.FormValue("branch")
+	rel := r.FormValue("path")
 	if err := validateRepo(repoName); err != nil {
 		fail(w, err)
 		return
 	}
-	if err := validateBranch(branch); err != nil || branch == "" {
-		fail(w, fmt.Errorf("invalid branch: %q", branch))
+	if err := validateBranch(rel); err != nil || rel == "" { // same path-shape rules
+		fail(w, fmt.Errorf("invalid worktree path: %q", rel))
 		return
 	}
 	run(w, r, "git", "-C", filepath.Join(gitRoot, repoName),
-		"worktree", "remove", "--force", "--force", filepath.Join(wtRoot, repoName, branch))
+		"worktree", "remove", "--force", "--force", filepath.Join(wtRoot, repoName, rel))
 }
 
 // run executes a command and, on success, redirects back to the index; on
@@ -342,11 +363,11 @@ var page = template.Must(template.New("page").Funcs(template.FuncMap{"ago": ago}
  <form method=post action=/spawn>
   <input type=hidden name=repo value="{{$repo}}">
   <input type=hidden name=branch value="{{.Branch}}">
-  <button>spawn</button> <code>{{.Branch}}</code> <span class=muted>{{ago .LastActive}}</span>
+  <button>spawn</button> <code>{{.Branch}}</code>{{if ne .Branch .Rel}} <span class=muted>in {{.Rel}}</span>{{end}} <span class=muted>{{ago .LastActive}}</span>
  </form>
- <form method=post action=/rmworktree onsubmit="return confirm('Remove worktree {{$repo}}/{{.Branch}}?')">
+ <form method=post action=/rmworktree onsubmit="return confirm('Remove worktree {{$repo}}/{{.Rel}}?')">
   <input type=hidden name=repo value="{{$repo}}">
-  <input type=hidden name=branch value="{{.Branch}}">
+  <input type=hidden name=path value="{{.Rel}}">
   <button>rm</button>
  </form>
 </li>{{end}}

--- a/pkgs/ac-web/main_test.go
+++ b/pkgs/ac-web/main_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // validateBranch is the exec trust boundary; empty is allowed (main repo),
@@ -52,6 +53,24 @@ func TestServerRe(t *testing.T) {
 	for _, s := range []string{"", "dotfiles", "ac-;rm", "ac- x", "../x"} {
 		if serverRe.MatchString(s) {
 			t.Errorf("serverRe accepted invalid %q", s)
+		}
+	}
+}
+
+func TestAgo(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		in   time.Time
+		want string
+	}{
+		{time.Time{}, ""},
+		{now.Add(-30 * time.Second), "just now"},
+		{now.Add(-3 * time.Hour), "3h"},
+		{now.Add(-2 * 24 * time.Hour), "2d"},
+	}
+	for _, c := range cases {
+		if got := ago(c.in); got != c.want {
+			t.Errorf("ago(%v) = %q, want %q", c.in, got, c.want)
 		}
 	}
 }

--- a/pkgs/scripts/ac.sh
+++ b/pkgs/scripts/ac.sh
@@ -453,7 +453,23 @@ cmd_remove() {
 	local target="$1"
 	local server
 	server=$(resolve_target "$target")
-	tmux -L "$server" kill-server
+
+	# Stop the agent gracefully: SIGTERM lets `claude remote-control` preserve
+	# its environment and deregister cleanly. A forced kill orphaned it and
+	# filled the claude.ai picker with dead duplicates. The agent runs as a
+	# child of the pane's shell, so signal the shell's children. Fall back to
+	# kill-server if it hasn't exited within the grace window.
+	local pane_pid
+	pane_pid=$(tmux -L "$server" list-panes -t work:agent -F '#{pane_pid}' 2>/dev/null | head -1)
+	if [[ -n "$pane_pid" ]]; then
+		pkill -TERM -P "$pane_pid" 2>/dev/null || true
+		for _ in $(seq 1 20); do # ~10s grace
+			pgrep -P "$pane_pid" >/dev/null 2>&1 || break
+			sleep 0.5
+		done
+	fi
+
+	tmux -L "$server" kill-server 2>/dev/null
 	echo "killed: $server"
 }
 

--- a/pkgs/scripts/ac.sh
+++ b/pkgs/scripts/ac.sh
@@ -91,19 +91,24 @@ create_branch_worktree() {
 	# Ensure the parent dir exists for nested branch names (e.g. feature/foo).
 	mkdir -p "$(dirname "$target_path")"
 
+	# Fetch and pick the base the branch would be created from.
+	local base
 	if git -C "$main_wt" remote | grep -q '^upstream$'; then
 		echo "Fetching upstream..."
 		git -C "$main_wt" fetch upstream
-		echo "Creating worktree at $target_path from upstream/main..."
-		git -C "$main_wt" worktree add "$target_path" -b "$branch" upstream/main
+		base="upstream/main"
 	else
-		# Determine origin's default branch
-		local base
 		base=$(git -C "$main_wt" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null |
 			sed 's@^refs/remotes/@@' || echo "origin/main")
-
 		echo "Fetching origin..."
 		git -C "$main_wt" fetch origin
+	fi
+
+	# If the branch already exists, check it out; otherwise create it from base.
+	if git -C "$main_wt" show-ref --verify --quiet "refs/heads/$branch"; then
+		echo "Checking out existing branch '$branch' at $target_path..."
+		git -C "$main_wt" worktree add "$target_path" "$branch"
+	else
 		echo "Creating worktree at $target_path from $base..."
 		git -C "$main_wt" worktree add "$target_path" -b "$branch" "$base"
 	fi
@@ -113,6 +118,41 @@ create_branch_worktree() {
 		echo "Allowing direnv in $target_path..."
 		direnv allow "$target_path"
 	fi
+}
+
+# ensure_worktree echoes the worktree dir for a branch, creating it if absent.
+# A branch already checked out is resolved to its actual worktree even when the
+# directory name differs from the branch (so we always end up in the right
+# place). With mode "interactive", prompts before creating; otherwise creates
+# silently. Progress goes to stderr so stdout is only the resolved path.
+ensure_worktree() {
+	local repo="$1" branch="$2" mode="${3:-}"
+
+	local main_wt existing
+	main_wt=$(find_main_worktree "$repo")
+
+	# Already checked out somewhere? Use that worktree, whatever it is named.
+	existing=$(git -C "$main_wt" worktree list --porcelain |
+		awk -v b="refs/heads/$branch" '/^worktree /{p=substr($0,10)} /^branch /{if($2==b){print p; exit}}')
+	if [[ -n "$existing" ]]; then
+		echo "$existing"
+		return 0
+	fi
+
+	# Conventional path under WT_ROOT.
+	local target_path="$WT_ROOT/$repo/$branch"
+	if [[ -d "$target_path" ]]; then
+		echo "$target_path"
+		return 0
+	fi
+
+	if [[ "$mode" == "interactive" ]]; then
+		local answer
+		read -rp "Branch '$branch' not found for $repo. Create? [y/N] " answer
+		[[ "$answer" =~ ^[Yy]$ ]] || return 1
+	fi
+	create_branch_worktree "$main_wt" "$target_path" "$branch" >&2
+	echo "$target_path"
 }
 
 server_alive() {
@@ -213,25 +253,13 @@ attach_session() {
 cmd_create_or_attach() {
 	local repo="$1" branch="${2:-}" agent="${3:-$DEFAULT_AGENT}"
 
-	# If a branch is specified and the worktree doesn't exist, offer to create it
-	if [[ -n "$branch" ]]; then
-		local target_path="$WT_ROOT/$repo/$branch"
-		if [[ ! -d "$target_path" ]]; then
-			local main_wt
-			main_wt=$(find_main_worktree "$repo")
-
-			local answer
-			read -rp "Branch '$branch' not found for $repo. Create? [y/N] " answer
-			if [[ "$answer" =~ ^[Yy]$ ]]; then
-				create_branch_worktree "$main_wt" "$target_path" "$branch"
-			else
-				return 1
-			fi
-		fi
-	fi
-
 	local dir effective_branch server
-	dir=$(resolve_path "$repo" "$branch")
+	if [[ -n "$branch" ]]; then
+		# Resolve to an existing worktree (creating on confirmation if none).
+		dir=$(ensure_worktree "$repo" "$branch" interactive) || return 1
+	else
+		dir=$(resolve_path "$repo" "")
+	fi
 	effective_branch=$(resolve_branch "$repo" "$branch")
 	server=$(server_name "$repo" "$effective_branch")
 
@@ -254,19 +282,14 @@ cmd_spawn() {
 	# attach later with `ac <repo> [branch]`.
 	local repo="$1" branch="${2:-}" agent="${3:-$DEFAULT_AGENT}"
 
-	# Create the branch worktree if it's missing (no prompt, unlike the
-	# interactive path).
-	if [[ -n "$branch" ]]; then
-		local target_path="$WT_ROOT/$repo/$branch"
-		if [[ ! -d "$target_path" ]]; then
-			local main_wt
-			main_wt=$(find_main_worktree "$repo")
-			create_branch_worktree "$main_wt" "$target_path" "$branch"
-		fi
-	fi
-
+	# Resolve to an existing worktree, creating it if missing (no prompt, unlike
+	# the interactive path).
 	local dir effective_branch server
-	dir=$(resolve_path "$repo" "$branch")
+	if [[ -n "$branch" ]]; then
+		dir=$(ensure_worktree "$repo" "$branch") || return 1
+	else
+		dir=$(resolve_path "$repo" "")
+	fi
 	effective_branch=$(resolve_branch "$repo" "$branch")
 	server=$(server_name "$repo" "$effective_branch")
 
@@ -455,7 +478,8 @@ Flags:
   -c, --claude           Use claude (default)
 
 If the branch worktree does not exist, you will be prompted to
-create it. The new branch is based on the appropriate remote:
+create it. An existing branch is checked out as-is; a new branch
+is based on the appropriate remote:
   - Repos with an 'upstream' remote: fetches upstream, branches
     from upstream/main (e.g., headscale forks)
   - All other repos: fetches origin, branches from origin's

--- a/pkgs/scripts/wt.fish
+++ b/pkgs/scripts/wt.fish
@@ -109,6 +109,15 @@ Examples of resolved paths:
   ~/worktrees/headscale/kradalby/2388-topic  (slashes kept as nested dirs)"
 end
 
+# __wt_land cd's into a worktree and allows its direnv, so you arrive ready to
+# work instead of hitting a "blocked" .envrc. Mirrors `ac`'s behaviour.
+function __wt_land --argument-names dir
+    cd "$dir"
+    if test -f "$dir/.envrc"; and command -v direnv >/dev/null 2>&1
+        direnv allow "$dir"
+    end
+end
+
 function __wt_get_default_base
     set -l base (git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
     test -n "$base" && echo $base || echo main
@@ -123,7 +132,7 @@ function __wt_checkout
     set -l existing (git worktree list | grep "\[$branch\]" | awk '{print $1}')
     if test -n "$existing"
         echo "Worktree already exists: $existing"
-        cd "$existing"
+        __wt_land "$existing"
         return 0
     end
 
@@ -132,7 +141,7 @@ function __wt_checkout
         mkdir -p (dirname "$path")
         git worktree add "$path" "$branch"
         echo "Worktree created at: $path"
-        cd "$path"
+        __wt_land "$path"
     else
         echo "Error: Branch '$branch' does not exist" >&2
         echo "Use 'wt create $branch' to create a new branch" >&2
@@ -150,14 +159,14 @@ function __wt_create
     set -l existing (git worktree list | grep "\[$branch\]" | awk '{print $1}')
     if test -n "$existing"
         echo "Worktree already exists: $existing"
-        cd "$existing"
+        __wt_land "$existing"
         return 0
     end
 
     mkdir -p (dirname "$path")
     git worktree add "$path" -b "$branch" "$base"
     echo "Worktree created at: $path"
-    cd "$path"
+    __wt_land "$path"
 end
 
 function __wt_pr
@@ -188,7 +197,7 @@ function __wt_pr
     set -l existing (git worktree list | grep "\[$branch\]" | awk '{print $1}')
     if test -n "$existing"
         echo "Worktree already exists: $existing"
-        cd "$existing"
+        __wt_land "$existing"
         return 0
     end
 
@@ -204,7 +213,7 @@ function __wt_pr
     mkdir -p (dirname "$path")
     git worktree add "$path" -b "$branch" $pr_head
     echo "PR #$pr_number checked out at: $path"
-    cd "$path"
+    __wt_land "$path"
 end
 
 function __wt_remove


### PR DESCRIPTION
Managing worktrees from the phone was painful once they piled up, and the underlying tooling disagreed about what a worktree *is*.

`ac-web`: repos and worktrees sort newest-first with an age label so live work floats up; the new-branch form moves above the list; each worktree gets a guarded `rm` (worktree only, branch kept) and `kill` confirms too. Worktrees are now identified by both their checked-out branch (spawn identity, so a phone spawn matches a CLI attach) and their path (delete identity), so a renamed worktree still spawns and deletes correctly.

`ac`: a branch resolves to wherever it is checked out even if the worktree dir was renamed, existing branches are checked out instead of failing on `-b`, and `rm` stops the agent with SIGTERM first so `claude remote-control` preserves state and deregisters instead of orphaning dead duplicates in the claude.ai picker.

`wt`: landing in a worktree now runs `direnv allow`, so `wt co/create/pr` arrive ready instead of on a blocked `.envrc` — matching `ac`.

Generated with the help of an AI assistant