### PR TITLE
rpi5: enable aarch64 builds via gigabuilder emulation

### DIFF
--- a/common/rnb-builders.nix
+++ b/common/rnb-builders.nix
@@ -57,4 +57,19 @@
     publicHostKey = "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUh3NTFUQ1BmWkxnbm5ZLzc5ZHZGNDdOc0pFZmptNy9oWVdleUxmZ0J2bUE=";
     hasRosetta = true;
   }
+
+  # dev.oracfurt via Tailscale (native aarch64-linux; real hardware, not qemu)
+  {
+    name = "dev.oracfurt";
+    host = "dev.oracfurt";
+    hostName = "dev-oracfurt.dalby.ts.net";
+    systems = ["aarch64-linux"];
+    sshUser = "root";
+    sshKey = ""; # Tailscale SSH — no key file (mac path in the entries above is wrong on linux)
+    maxJobs = 4;
+    speedFactor = 2;
+    supportedFeatures = ["big-parallel" "kvm" "nixos-test"];
+    publicHostKey = "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUU2NXMvaFJuMzR2NVVOaFNJQzgvSk4vNDUyaExkcW4xMzFnVnFxQlRQbmwgcm9vdEBkZXYK";
+    hasRosetta = false;
+  }
 ]

--- a/flake.lock
+++ b/flake.lock
@@ -1098,16 +1098,16 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1779023229,
-        "narHash": "sha256-MInilg7B/06c34SwOuGSBho4l0H1EZcmvxTkSWCs5pE=",
+        "lastModified": 1782759863,
+        "narHash": "sha256-Eamu+EEgeAzIzYp4WDokk83NqikVtf75XLAKIAvV2Lc=",
         "owner": "nvmd",
         "repo": "nixos-raspberrypi",
-        "rev": "06c6e3513e1ee64b651913193fc6ac38aa4963f5",
+        "rev": "18d06426a3ea858b8afe4fe967be57d3723f4799",
         "type": "github"
       },
       "original": {
         "owner": "nvmd",
-        "ref": "main",
+        "ref": "nixos-26.05",
         "repo": "nixos-raspberrypi",
         "type": "github"
       }
@@ -1242,16 +1242,16 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1778737229,
-        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
+        "lastModified": 1782535326,
+        "narHash": "sha256-ZeRxu4yn6shd3SNF5ZUQb4r7BaVo1zBKMjRhfoNSBmw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
+        "rev": "714a5f8c4ead6b31148d829288440ed033ccc041",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -162,7 +162,7 @@
     # Stock nixpkgs sd-image-aarch64 has no Pi5 support (no bcm2712 DTB,
     # u-boot, or [pi5] config.txt). nixos-raspberrypi ships proper Pi5
     # firmware + sd-image generator.
-    nixos-raspberrypi.url = "github:nvmd/nixos-raspberrypi/main";
+    nixos-raspberrypi.url = "github:nvmd/nixos-raspberrypi/nixos-26.05";
   };
 
   outputs = {
@@ -339,35 +339,40 @@
             buildOnTarget = true;
           };
 
-          # Out of rotation.
-          # "rpi5.ldn" = box.nixosBox {
-          #   arch = "aarch64-linux";
-          #   name = "rpi5.ldn";
-          #   tags = ["arm64" "ldn"];
-          #   # LAN IP for the first deploy before the host joins
-          #   # tailscale. Drop to null once rpi5-ldn.<tailnet> resolves.
-          #   # targetHost = "10.65.0.196";
-          #   modules = with inputs; [
-          #     # raspberry-pi-5 modules consume nixos-raspberrypi as a
-          #     # module argument (normally set by the flake's own
-          #     # lib.nixosSystem via specialArgs). box.nixosBox calls
-          #     # plain nixpkgs.lib.nixosSystem so we wire the arg in.
-          #     ({...}: {_module.args.nixos-raspberrypi = nixos-raspberrypi;})
-          #     nixos-raspberrypi.nixosModules.raspberry-pi-5.base
-          #     nixos-raspberrypi.nixosModules.raspberry-pi-5.page-size-16k
-          #     nixos-raspberrypi.nixosModules.nixpkgs-rpi
-          #     nixos-raspberrypi.nixosModules.trusted-nix-caches
-          #     ({...}: {
-          #       nixpkgs.overlays = [
-          #         nixos-raspberrypi.overlays.bootloader
-          #         nixos-raspberrypi.overlays.vendor-kernel
-          #         nixos-raspberrypi.overlays.vendor-firmware
-          #         nixos-raspberrypi.overlays.kernel-and-firmware
-          #         nixos-raspberrypi.overlays.vendor-pkgs
-          #       ];
-          #     })
-          #   ];
-          # };
+          # rpi5: aarch64, built on gigabuilder via emulation. nixpkgs-rpi +
+          # the vendor overlays align its derivations with nixos-raspberrypi's
+          # cachix, and trusted-nix-caches puts that cache on the Pi itself.
+          "rpi5.ldn" = box.nixosBox {
+            arch = "aarch64-linux";
+            # Build on nixos-raspberrypi's own nixpkgs pin — that's what their
+            # cachix was built against, so the kernel/firmware come from cache
+            # instead of rebuilding under emulation.
+            nixpkgs = inputs.nixos-raspberrypi.inputs.nixpkgs;
+            name = "rpi5.ldn";
+            tags = ["arm64" "ldn"];
+            # LAN IP for the first deploy before the host joins tailscale.
+            # targetHost = "10.65.0.196";
+            modules = with inputs; [
+              # raspberry-pi-5 modules consume nixos-raspberrypi as a module
+              # argument (normally set by the flake's own lib.nixosSystem via
+              # specialArgs). box.nixosBox calls plain nixpkgs.lib.nixosSystem so
+              # we wire the arg in.
+              ({...}: {_module.args.nixos-raspberrypi = nixos-raspberrypi;})
+              nixos-raspberrypi.nixosModules.raspberry-pi-5.base
+              nixos-raspberrypi.nixosModules.raspberry-pi-5.page-size-16k
+              nixos-raspberrypi.nixosModules.nixpkgs-rpi
+              nixos-raspberrypi.nixosModules.trusted-nix-caches
+              ({...}: {
+                nixpkgs.overlays = [
+                  nixos-raspberrypi.overlays.bootloader
+                  nixos-raspberrypi.overlays.vendor-kernel
+                  nixos-raspberrypi.overlays.vendor-firmware
+                  nixos-raspberrypi.overlays.kernel-and-firmware
+                  nixos-raspberrypi.overlays.vendor-pkgs
+                ];
+              })
+            ];
+          };
 
           "storage.ldn" = box.nixosBox {
             arch = "x86_64-linux";

--- a/machines/garnix/default.nix
+++ b/machines/garnix/default.nix
@@ -67,6 +67,12 @@ in {
   nix.settings = {
     min-free = 10 * 1024 * 1024 * 1024;
     max-free = 30 * 1024 * 1024 * 1024;
+    # rpi (aarch64) builds offload to gigabuilder but the coordinator may
+    # pre-substitute — let it pull the rpi kernel/firmware from cachix too.
+    substituters = ["https://nixos-raspberrypi.cachix.org"];
+    trusted-public-keys = [
+      "nixos-raspberrypi.cachix.org-1:4iMO9LXa8BqhU+Rpg6LQKiGa2lsNh/j2oiYLNOQ5sPI="
+    ];
   };
   garnix.custom-gc.targetPercent = 60;
 
@@ -118,7 +124,9 @@ in {
         name = "gigabuilder";
         hostname = "10.68.0.1"; # host over incusbr0 (a trustedInterface)
         user = "nix-ssh";
-        systems = ["x86_64-linux"];
+        # aarch64 (rpi5) offloads here too — gigabuilder builds it via qemu
+        # emulation, pulling the rpi kernel/firmware from cachix.
+        systems = ["x86_64-linux" "aarch64-linux"];
         maxJobs = 16;
         speedFactor = 4;
         supportedFeatures = ["big-parallel" "kvm" "nixos-test"];

--- a/machines/gigabuilder/default.nix
+++ b/machines/gigabuilder/default.nix
@@ -63,5 +63,14 @@
 
   monitoring.smartctl.devices = ["/dev/nvme0n1" "/dev/nvme1n1"];
 
+  # Build aarch64 (rpi5) here via qemu user emulation. The heavy rpi packages
+  # (linux-rpi kernel, firmware, u-boot) come from nixos-raspberrypi's cachix, so
+  # emulation only assembles the trivial config bits — never the kernel.
+  boot.binfmt.emulatedSystems = ["aarch64-linux"];
+  nix.settings.substituters = ["https://nixos-raspberrypi.cachix.org"];
+  nix.settings.trusted-public-keys = [
+    "nixos-raspberrypi.cachix.org-1:4iMO9LXa8BqhU+Rpg6LQKiGa2lsNh/j2oiYLNOQ5sPI="
+  ];
+
   system.stateVersion = "25.11";
 }

--- a/machines/rpi5.ldn/default.nix
+++ b/machines/rpi5.ldn/default.nix
@@ -45,13 +45,17 @@
   # alacritty, …) — a large aarch64 build under emulation for nothing.
   environment.enableAllTerminfo = lib.mkForce false;
 
-  # ripgrep/mdbook test suites panic under qemu-user emulation; the binaries are
-  # fine. Skip checks so the emulated aarch64 build completes.
+  # These test suites hang/fail under qemu-user emulation (the binaries build
+  # fine); nixos-raspberrypi's nixpkgs pin is ahead of Hydra's aarch64 cache, so
+  # they're compiled here rather than fetched. Skip checks to let the build pass.
   nixpkgs.overlays = [
-    (_: prev: {
-      ripgrep = prev.ripgrep.overrideAttrs (_: {doCheck = false;});
-      mdbook = prev.mdbook.overrideAttrs (_: {doCheck = false;});
-    })
+    (_: prev:
+      lib.genAttrs ["ripgrep" "mdbook" "git" "mercurial"]
+      (n:
+        prev.${n}.overrideAttrs (_: {
+          doCheck = false;
+          doInstallCheck = false;
+        })))
   ];
 
   # nixos-raspberrypi is migrating the default from "kernelboot" to

--- a/machines/rpi5.ldn/default.nix
+++ b/machines/rpi5.ldn/default.nix
@@ -41,6 +41,19 @@
 
   services.tailscale.tags = ["tag:ldn" "tag:server"];
 
+  # Headless: don't pull every terminal emulator's terminfo (contour → qtbase,
+  # alacritty, …) — a large aarch64 build under emulation for nothing.
+  environment.enableAllTerminfo = lib.mkForce false;
+
+  # ripgrep/mdbook test suites panic under qemu-user emulation; the binaries are
+  # fine. Skip checks so the emulated aarch64 build completes.
+  nixpkgs.overlays = [
+    (_: prev: {
+      ripgrep = prev.ripgrep.overrideAttrs (_: {doCheck = false;});
+      mdbook = prev.mdbook.overrideAttrs (_: {doCheck = false;});
+    })
+  ];
+
   # nixos-raspberrypi is migrating the default from "kernelboot" to
   # "kernel"; opt in explicitly to silence the deprecation warning.
   boot.loader.raspberry-pi.bootloader = "kernel";


### PR DESCRIPTION
Bring the Raspberry Pi 5 back into the fleet. It's `aarch64-linux` and nothing built arm — gigabuilder is x86.

gigabuilder now builds `aarch64-linux` via qemu user emulation, and garnix offloads aarch64 realisation to it. Emulation would be brutal for the RPi kernel, so gigabuilder trusts `nixos-raspberrypi.cachix.org` — its kernel/firmware are byte-identical to what upstream CI caches, so they're substituted, never compiled (verified by dry-run).

`nixos-raspberrypi`'s `main` still tracks 25.11 (incompatible with our 26.05 `common`), so this pins their `nixos-26.05` branch and builds `rpi5.ldn` on their nixpkgs — 26.05-compatible and cache-matching. Their 26.05 installer builds are still shaking out upstream (nvmd/nixos-raspberrypi#212), but that doesn't touch the kernel path we consume.

The remaining aarch64 packages our `common` pulls in aren't in any cache for this pin and would crawl under emulation. So `rnb`'s registry gains `dev.oracfurt` — real aarch64 hardware — to offload those from `dev.ldn` onto native silicon, landing them in tsnixcache for the fleet. gigabuilder + garnix changes are already deployed live.

> Generated with the help of an AI assistant