### PR TITLE
machines/oracle: back in rotation with stable IPs and IPv6

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -287,30 +287,28 @@
           #   tags = ["x86" "router" "terra"];
           # };
 
-          # Out of rotation.
-          # "core.oracldn" = box.nixosBox {
-          #   arch = "aarch64-linux";
-          #   name = "core.oracldn";
-          #   tags = ["arm64" "oracle" "oracldn"];
-          #   modules = with inputs; [
-          #     headscale.nixosModules.default
-          #     golink.nixosModules.default
-          #     krapage.nixosModules.default
-          #     hvor.nixosModules.default
-          #     tasmota-exporter.nixosModules.default
-          #     homewizard-p1-exporter.nixosModules.default
-          #   ];
-          # };
+          "core.oracldn" = box.nixosBox {
+            arch = "aarch64-linux";
+            name = "core.oracldn";
+            tags = ["arm64" "oracle" "oracldn"];
+            modules = with inputs; [
+              headscale.nixosModules.default
+              golink.nixosModules.default
+              krapage.nixosModules.default
+              hvor.nixosModules.default
+              tasmota-exporter.nixosModules.default
+              homewizard-p1-exporter.nixosModules.default
+            ];
+          };
 
-          # Out of rotation.
-          # "dev.oracfurt" = box.nixosBox {
-          #   arch = "aarch64-linux";
-          #   name = "dev.oracfurt";
-          #   tags = ["arm64" "oracle" "oracfurt"];
-          #   modules = with inputs; [
-          #     tsidp.nixosModules.default
-          #   ];
-          # };
+          "dev.oracfurt" = box.nixosBox {
+            arch = "aarch64-linux";
+            name = "dev.oracfurt";
+            tags = ["arm64" "oracle" "oracfurt"];
+            modules = with inputs; [
+              tsidp.nixosModules.default
+            ];
+          };
 
           "home.ldn" = box.nixosBox {
             arch = "x86_64-linux";

--- a/machines/core.oracldn/default.nix
+++ b/machines/core.oracldn/default.nix
@@ -43,6 +43,21 @@
     interfaces = {
       "${config.my.wan}" = {
         useDHCP = true;
+        # Stable reserved public IP (152.67.129.235) NATs to this
+        # secondary private IP; DHCP keeps the primary private IP,
+        # which carries the ephemeral public IP.
+        ipv4.addresses = [
+          {
+            address = "192.168.122.10";
+            prefixLength = 24;
+          }
+        ];
+        ipv6.addresses = [
+          {
+            address = "2603:c020:c013:2600::10";
+            prefixLength = 64;
+          }
+        ];
       };
 
       ${config.my.lan} = {
@@ -90,11 +105,18 @@
       allowedUDPPorts = lib.mkForce [
         443 # HTTPS
         config.services.tailscale.port
-
       ];
 
       trustedInterfaces = [config.my.lan "docker0"];
     };
+  };
+
+  boot.kernel.sysctl = {
+    # IPv6 default route comes from OCI router advertisements; accept_ra=2
+    # keeps that working with forwarding enabled. No SLAAC (autoconf=0):
+    # OCI only routes addresses explicitly assigned to the VNIC.
+    "net.ipv6.conf.${config.my.wan}.accept_ra" = 2;
+    "net.ipv6.conf.${config.my.wan}.autoconf" = 0;
   };
 
   services.tailscale = {

--- a/machines/core.oracldn/grafana.nix
+++ b/machines/core.oracldn/grafana.nix
@@ -82,7 +82,13 @@ in {
         enable_login_token = true;
       };
 
-      security.admin_password = "$__file{${config.age.secrets.grafana-admin.path}}";
+      security = {
+        admin_password = "$__file{${config.age.secrets.grafana-admin.path}}";
+        # NixOS 26.05 requires an explicit secret_key; this is the old
+        # upstream default the existing DB is encrypted with. Nothing
+        # sensitive lives in it (single passwordless local datasource).
+        secret_key = "SW2YcwTIb9zpOOhoPsMm";
+      };
 
       smtp = {
         enable = true;

--- a/machines/dev.oracfurt/default.nix
+++ b/machines/dev.oracfurt/default.nix
@@ -29,7 +29,24 @@
     domain = "oracfurt.fap.no";
     usePredictableInterfaceNames = lib.mkForce true;
 
-    interfaces.${config.my.wan}.useDHCP = true;
+    interfaces.${config.my.wan} = {
+      useDHCP = true;
+      # Stable reserved public IP (129.159.30.250) NATs to this
+      # secondary private IP; DHCP keeps the primary private IP,
+      # which carries the ephemeral public IP.
+      ipv4.addresses = [
+        {
+          address = "192.168.122.10";
+          prefixLength = 24;
+        }
+      ];
+      ipv6.addresses = [
+        {
+          address = "2603:c020:8026:db00::10";
+          prefixLength = 64;
+        }
+      ];
+    };
     interfaces.${config.my.lan} = {
       useDHCP = false;
       ipv4.addresses = [
@@ -68,13 +85,19 @@
       allowedUDPPorts = lib.mkForce [
         443 # HTTPS
         config.services.tailscale.port
-
       ];
 
       trustedInterfaces = [config.my.lan];
     };
   };
 
+  boot.kernel.sysctl = {
+    # IPv6 default route comes from OCI router advertisements; accept_ra=2
+    # keeps that working with forwarding enabled. No SLAAC (autoconf=0):
+    # OCI only routes addresses explicitly assigned to the VNIC.
+    "net.ipv6.conf.${config.my.wan}.accept_ra" = 2;
+    "net.ipv6.conf.${config.my.wan}.autoconf" = 0;
+  };
 
   services.tailscale = {
     advertiseRoutes = ["10.67.0.0/16"];


### PR DESCRIPTION
Oracle changed the always-free tier (June 2026), so both A1 VMs were resized to 2 OCPU/12GB and restarted; infra side (reserved IPs, IPv6, firewall) is already applied via tofu in the infrastructure repo.

Each host gains a secondary private IPv4 (`192.168.122.10`) that the new reserved public IP NATs to (core: `152.67.129.235`, dev: `129.159.30.250`), and a static IPv6 (`2603:c020:c013:2600::10` / `2603:c020:8026:db00::10`). Default v6 route comes from OCI RAs (`accept_ra=2`, SLAAC off — OCI only routes VNIC-assigned addresses). The ephemeral public IPs stay on the primary private IPs.

`core.oracldn` needed a grafana `secret_key` pin: NixOS 26.05 requires it explicitly, and the DB is encrypted with the old upstream default; nothing sensitive stored.

Both machines go back into `nixosConfigurations` (they were out of rotation while shut off).

DNS still points at the ephemeral IPs; the tofu repoint to the reserved IPs + AAAA records happens after this deploys. Validated with `nix eval` of both toplevels; deploy with `colmena apply` and check `ip -6 route` shows a default via RA.

> Generated with the help of an AI assistant