### PR TITLE
litestream: off-site single replica to tjoda minio

### DIFF
--- a/common/litestream.nix
+++ b/common/litestream.nix
@@ -8,6 +8,9 @@ with lib; let
   port = 54909;
   replicate = db: {
     inherit (db) path;
+    # litestream >= 0.5 allows one replica per database. Keep the local
+    # minio (reachable); off-site coverage comes from restic. tjoda's
+    # minio (10.62.0.1:9000) was unreachable when this was cut down.
     replicas = [
       {
         name = "oracldn";
@@ -15,15 +18,6 @@ with lib; let
         bucket = "databases";
         path = db.name;
         endpoint = "http://minio.oracldn.fap.no:9000";
-        region = "us-east-1";
-        validation-interval = "24h";
-      }
-      {
-        name = "tjoda";
-        type = "s3";
-        bucket = "databases";
-        path = db.name;
-        endpoint = "http://minio.tjoda.fap.no:9000";
         region = "us-east-1";
         validation-interval = "24h";
       }

--- a/common/litestream.nix
+++ b/common/litestream.nix
@@ -8,16 +8,17 @@ with lib; let
   port = 54909;
   replicate = db: {
     inherit (db) path;
-    # litestream >= 0.5 allows one replica per database. Keep the local
-    # minio (reachable); off-site coverage comes from restic. tjoda's
-    # minio (10.62.0.1:9000) was unreachable when this was cut down.
+    # litestream >= 0.5 allows one replica per database. Replicate
+    # off-site to tjoda's minio (a local replica on the same host is no
+    # DR) over its tailnet VIP service; reachable via the svc:minio-tjoda
+    # grant. restic covers file-level off-site backup.
     replicas = [
       {
-        name = "oracldn";
+        name = "tjoda";
         type = "s3";
         bucket = "databases";
         path = db.name;
-        endpoint = "http://minio.oracldn.fap.no:9000";
+        endpoint = "http://minio-tjoda.dalby.ts.net:9000";
         region = "us-east-1";
         validation-interval = "24h";
       }

--- a/common/minio.nix
+++ b/common/minio.nix
@@ -22,6 +22,9 @@ in {
     endpoints = {
       "tcp:80" = "http://${consoleAddress}";
       "tcp:443" = "http://${consoleAddress}";
+      # S3 API for cross-site consumers (litestream replicas, backups);
+      # reachable via the svc:minio-* grants in the tailnet policy.
+      "tcp:9000" = "http://127.0.0.1:9000";
     };
   };
 }

--- a/machines/core.oracldn/litestream.nix
+++ b/machines/core.oracldn/litestream.nix
@@ -34,4 +34,9 @@
       };
     };
   };
+
+  # litestream (in the headscale group) writes its shadow dir inside the
+  # headscale state dir; the module default 0750 denies group write, so
+  # headscale replication silently failed. kuma/golink dirs are 0770.
+  systemd.services.headscale.serviceConfig.StateDirectoryMode = lib.mkForce "0770";
 }


### PR DESCRIPTION
litestream 0.5 (via the 26.05 bump) dropped multi-replica support, so the service crash-looped on core.oracldn. Collapse to a single replica and point it **off-site** at tjoda's minio over its tailnet VIP service — a replica on the same host is no disaster recovery.

Depends on svc:minio-tjoda reachability, added in the infrastructure repo (tailnet policy grant + tofu-managed `tailscale_service`); minio's S3 API is now surfaced as a VIP endpoint on tcp:9000.

Also fixes a latent bug: `/var/lib/headscale` was mode 0750, so litestream (in the headscale group) could never create its shadow dir there — headscale db replication had been silently failing. Set 0770 to match the kuma/golink state dirs.

Verified on core.oracldn: all three DBs (golink, kuma, headscale) replicate to tjoda with zero errors, and `{golink.db,kuma.db,headscale.sqlite}/generations` objects confirmed present in tjoda's bucket. Already deployed.

> Generated with the help of an AI assistant