### PR TITLE
machines: back up the fleet to Jottacloud via a restic proxy on core.tjoda

### DIFF
--- a/checks/prometheus-rules/tests.yaml
+++ b/checks/prometheus-rules/tests.yaml
@@ -111,6 +111,64 @@ tests:
               summary: "Restic jotta on h1: no successful offsite backup for 8h"
               description: "The Jottacloud job is the only offsite copy of /storage; slow rclone uploads get 8h of slack, silence beyond that is real."
 
+  # Jotta proxy: a failed VIP probe pages after 15m.
+  - interval: 1m
+    input_series:
+      - series: 'probe_success{job="restic-jotta-probe", instance="http://restic-jotta.dalby.ts.net"}'
+        values: "0x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: ResticJottaProxyDown
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: restic-jotta-probe
+              instance: http://restic-jotta.dalby.ts.net
+            exp_annotations:
+              summary: "Jotta restic proxy is not answering on its VIP"
+              description: "restic-jotta.dalby.ts.net is unreachable: rclone-jotta.service on core.tjoda is down, the VIP advertisement broke, or the grant changed. Every host's offsite backup fails until this is back."
+
+  # Jotta proxy traffic cross-check: proxy up with a frozen transfer counter
+  # fires (and the canary stays quiet — the series exists). A counter that
+  # never moves has increase()==0 over any partial window, so a short series
+  # exercises the 26h rule.
+  - interval: 1m
+    input_series:
+      - series: 'rclone_bytes_transferred_total{job="rclone-jotta", instance="core-tjoda:56901", host="core-tjoda"}'
+        values: "100x200"
+      - series: 'up{job="rclone-jotta", instance="core-tjoda:56901", host="core-tjoda"}'
+        values: "1x200"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: ResticJottaProxyNoTraffic
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "No bytes moved through the Jotta restic proxy in 26h"
+              description: "The proxy is up but no client backup has pushed data through it for over a day; check the client jotta jobs and the token-check unit on core.tjoda."
+      - eval_time: 2h
+        alertname: ResticJottaProxyMetricsMissing
+        exp_alerts: []
+
+  # Jotta proxy metric-rename canary: scrape up, expected series absent → page.
+  - interval: 1m
+    input_series:
+      - series: 'up{job="rclone-jotta", instance="core-tjoda:56901", host="core-tjoda"}'
+        values: "1x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: ResticJottaProxyMetricsMissing
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "Jotta proxy scrape is up but rclone_bytes_transferred_total is absent"
+              description: "The rclone metric names have changed (version bump?); ResticJottaProxyNoTraffic is blind until the rules are updated."
+      - eval_time: 20m
+        alertname: ResticJottaProxyNoTraffic
+        exp_alerts: []
+
   # Litestream: sync errors page; and the sloth SLI records the right ratio
   # (1 error/min against 2 ops/min = 0.5).
   - interval: 1m

--- a/machines/core.oracldn/monitoring.nix
+++ b/machines/core.oracldn/monitoring.nix
@@ -106,6 +106,18 @@
           valid_status_codes: [200, 301, 302, 401, 403]
           fail_if_ssl: false
           fail_if_not_ssl: false
+      # restic REST endpoints answer 404 on / — any HTTP status proves the
+      # VIP → daemon path (a dead backend is a connection error, not a 404).
+      http_restic:
+        prober: http
+        timeout: 5s
+        http:
+          method: GET
+          preferred_ip_protocol: "ip4"
+          ip_protocol_fallback: false
+          valid_status_codes: [200, 404, 405]
+          fail_if_ssl: false
+          fail_if_not_ssl: false
       # End-to-end DNS through each site's CoreDNS resolver.
       dns:
         prober: dns
@@ -265,6 +277,12 @@ in {
         ];
         relabel_configs = [hostRelabel];
       }
+
+      # rclone serve restic (Jotta proxy) on core.tjoda: core transfer stats
+      # only — no per-repo series like rest-server (rclone#7980). Target-down
+      # is covered by the generic up==0 alert; the traffic cross-check and
+      # metric-rename canary live in the backup rules below.
+      (scrapeJob "rclone-jotta" ["core-tjoda:56901"])
 
       # Pushgateway: backup success timestamps, sfiber proxy state, rustic
       # laptops — anything Prometheus has no route into pushes here.
@@ -443,6 +461,14 @@ in {
         "http://owntone.dalby.ts.net"
         "http://core-tjoda:9000/minio/health/live"
       ])
+
+      # The Jotta offsite path: VIP → rclone serve restic on core.tjoda. Every
+      # fleet host's only offsite copy rides this endpoint, so it gets its own
+      # probe and alert rather than the generic tailnet tier.
+      (probeJob "restic-jotta-probe" "http_restic" [
+        "http://restic-jotta.dalby.ts.net"
+      ])
+
       (probeJob "dns-probes" "dns" [
         "10.66.0.1"
         "10.62.0.2"
@@ -1360,6 +1386,45 @@ in {
                 annotations = {
                   summary = "No new snapshots written to repo {{ $labels.repo }} in 26h";
                   description = "No client has completed a backup into this repository for over a day.";
+                };
+              }
+              # Jotta proxy (rclone serve restic on core.tjoda): the whole
+              # fleet's offsite path. Warning tier — the per-client
+              # ResticBackupNotSucceedingJotta criticals are the backstop.
+              {
+                alert = "ResticJottaProxyDown";
+                expr = ''probe_success{job="restic-jotta-probe"} == 0'';
+                for = "15m";
+                labels.severity = "warning";
+                annotations = {
+                  summary = "Jotta restic proxy is not answering on its VIP";
+                  description = "restic-jotta.dalby.ts.net is unreachable: rclone-jotta.service on core.tjoda is down, the VIP advertisement broke, or the grant changed. Every host's offsite backup fails until this is back.";
+                };
+              }
+              {
+                alert = "ResticJottaProxyNoTraffic";
+                # Repo-side cross-check, the rest_server_blob_write equivalent
+                # for the proxy: rclone only has core transfer stats, but
+                # hourly client backups mean bytes must flow daily. Counter
+                # resets on restart, hence increase() guarded by up.
+                expr = ''sum(increase(rclone_bytes_transferred_total{job="rclone-jotta"}[26h])) == 0 and on () up{job="rclone-jotta"} == 1'';
+                for = "1h";
+                labels.severity = "warning";
+                annotations = {
+                  summary = "No bytes moved through the Jotta restic proxy in 26h";
+                  description = "The proxy is up but no client backup has pushed data through it for over a day; check the client jotta jobs and the token-check unit on core.tjoda.";
+                };
+              }
+              {
+                alert = "ResticJottaProxyMetricsMissing";
+                # Metric-rename canary: without it a renamed series turns the
+                # no-traffic cross-check silently green.
+                expr = ''absent(rclone_bytes_transferred_total) and on () up{job="rclone-jotta"} == 1'';
+                for = "15m";
+                labels.severity = "warning";
+                annotations = {
+                  summary = "Jotta proxy scrape is up but rclone_bytes_transferred_total is absent";
+                  description = "The rclone metric names have changed (version bump?); ResticJottaProxyNoTraffic is blind until the rules are updated.";
                 };
               }
               {

--- a/machines/core.oracldn/restic.nix
+++ b/machines/core.oracldn/restic.nix
@@ -21,5 +21,19 @@ in {
   services.restic.jobs = {
     tjoda = mkJob "tjoda";
     ldn = mkJob "ldn";
+    # Offsite via the Jotta proxy on core.tjoda (no Jotta credentials here).
+    # targetHost is the opaque repo name on Jotta — house convention, nothing
+    # host-identifying on the provider side.
+    jotta =
+      mkJob "jotta"
+      // {
+        targetHost = "f553137cb49962eeb9f01cb958dfcf95";
+        # Jotta egress is paid/slow: verify metadata only, monthly. The REST
+        # repos get the read-data checks.
+        check = {
+          args = [];
+          interval = "monthly";
+        };
+      };
   };
 }

--- a/machines/core.tjoda/default.nix
+++ b/machines/core.tjoda/default.nix
@@ -21,6 +21,7 @@
     ./samba.nix
     ./avahi.nix
     ./restic.nix
+    ./restic-jotta.nix
     ./minio.nix
     ./sfiber-check.nix
   ];

--- a/machines/core.tjoda/restic-jotta.nix
+++ b/machines/core.tjoda/restic-jotta.nix
@@ -11,17 +11,10 @@
 in {
   # restic REST proxy fronting Jottacloud: tailnet hosts back up offsite via
   # rest:http://restic-jotta.dalby.ts.net/<scrambled> without holding Jotta
-  # credentials. This service owns the ONLY Jotta token family for the proxy —
-  # separate from root's config used by this host's own direct jotta job
-  # (./restic.nix); Jotta rotates the refresh token on every refresh, so the
-  # config must be persistent, writable, and never shared or restored from
-  # backup.
-  #
-  # One-off manual login (single-use token from
-  # https://www.jottacloud.com/web/secure, expires in minutes; only one
-  # login-token bring-up at a time account-wide):
-  #   rclone --config /var/lib/rclone-jotta/rclone.conf config create Jotta jottacloud config_type=standard config_login_token=<token>
-  #   chown -R rclone-jotta:rclone-jotta /var/lib/rclone-jotta
+  # credentials. This service owns the ONLY Jotta login on this host — the
+  # local jotta job (./restic.nix) also goes through it. Jotta rotates the
+  # refresh token on every refresh, so the config must be persistent,
+  # writable, and never copied (a diverging copy kills the token family).
 
   users.users.rclone-jotta = {
     isSystemUser = true;

--- a/machines/core.tjoda/restic-jotta.nix
+++ b/machines/core.tjoda/restic-jotta.nix
@@ -1,0 +1,94 @@
+{
+  pkgs,
+  config,
+  ...
+}: let
+  port = 56900;
+  metricsPort = 56901;
+  stateDir = "/var/lib/rclone-jotta";
+  rcloneConf = "${stateDir}/rclone.conf";
+  rclone = "${pkgs.rclone}/bin/rclone --config ${rcloneConf}";
+in {
+  # restic REST proxy fronting Jottacloud: tailnet hosts back up offsite via
+  # rest:http://restic-jotta.dalby.ts.net/<scrambled> without holding Jotta
+  # credentials. This service owns the ONLY Jotta token family for the proxy —
+  # separate from root's config used by this host's own direct jotta job
+  # (./restic.nix); Jotta rotates the refresh token on every refresh, so the
+  # config must be persistent, writable, and never shared or restored from
+  # backup.
+  #
+  # One-off manual login (single-use token from
+  # https://www.jottacloud.com/web/secure, expires in minutes; only one
+  # login-token bring-up at a time account-wide):
+  #   rclone --config /var/lib/rclone-jotta/rclone.conf config create Jotta jottacloud config_type=standard config_login_token=<token>
+  #   chown -R rclone-jotta:rclone-jotta /var/lib/rclone-jotta
+
+  users.users.rclone-jotta = {
+    isSystemUser = true;
+    group = "rclone-jotta";
+  };
+  users.groups.rclone-jotta = {};
+
+  systemd.services.rclone-jotta = {
+    description = "restic REST proxy for Jottacloud";
+    wantedBy = ["multi-user.target"];
+    after = ["network-online.target"];
+    wants = ["network-online.target"];
+
+    serviceConfig = {
+      User = "rclone-jotta";
+      Group = "rclone-jotta";
+      StateDirectory = "rclone-jotta";
+      Restart = "on-failure";
+      RestartSec = "30";
+      # Serves the Jotta root: repos are opaque per-host folders alongside the
+      # existing direct-job repos (house convention: scrambled names, nothing
+      # host-identifying on the provider side).
+      ExecStart =
+        "${rclone} serve restic"
+        + " --addr 127.0.0.1:${toString port}"
+        # Restic packs (~16MiB) exceed the 10MiB default and would buffer via
+        # tempdir; Jotta needs the MD5 before upload.
+        + " --jottacloud-md5-memory-limit 32Mi"
+        # Client prunes must actually free quota; default deletes linger in
+        # Jotta trash for 30 days and still count.
+        + " --jottacloud-hard-delete"
+        + " --metrics-addr :${toString metricsPort}"
+        + " Jotta:";
+    };
+  };
+
+  # Early warning for token-family death (invalid_grant): a failed listing
+  # fails the unit and the fleet-wide ServiceFailed alert pages, instead of
+  # waiting for every client's jotta backup to go stale.
+  systemd.services.rclone-jotta-token-check = {
+    description = "Jottacloud token health check";
+    serviceConfig = {
+      Type = "oneshot";
+      User = "rclone-jotta";
+      Group = "rclone-jotta";
+      ExecStart = "${rclone} lsd Jotta:";
+    };
+  };
+  systemd.timers.rclone-jotta-token-check = {
+    wantedBy = ["timers.target"];
+    timerConfig = {
+      OnCalendar = "daily";
+      Persistent = true;
+      RandomizedDelaySec = "1h";
+    };
+  };
+
+  services.tailscale.services.restic-jotta = {
+    endpoints = {
+      "tcp:80" = "http://127.0.0.1:${toString port}";
+      # tcp:443 has no TLS termination — Tailscale VIP bug (tailscale/tailscale#19724, #18381); consumers use http. TODO(kradalby): revert when fixed.
+      "tcp:443" = "http://127.0.0.1:${toString port}";
+    };
+  };
+
+  # rclone core metrics (no per-repo series — see rclone#7980); scraped as
+  # core-tjoda:56901. ACL-approved port: needs the matching grant for
+  # tag:monitoring in infrastructure/tailscale/policy.hujson.
+  networking.firewall.interfaces.tailscale0.allowedTCPPorts = [metricsPort];
+}

--- a/machines/core.tjoda/restic.nix
+++ b/machines/core.tjoda/restic.nix
@@ -13,13 +13,13 @@
     # config.services.minio.configDir
   ];
 in {
-  # Jotta needs a one-off manual rclone login on this host (root). Get a
-  # personal login token at https://www.jottacloud.com/web/secure (single-use,
-  # expires in minutes), then run:
-  #   rclone config create Jotta jottacloud config_type=standard config_login_token=<token>
+  # Same repo the old direct rclone:Jotta: job wrote (the proxy serves the
+  # Jotta root), now via the local proxy — its state dir holds this host's
+  # only Jotta login (./restic-jotta.nix). localhost, not the VIP: local
+  # backups shouldn't depend on the tailnet.
   services.restic.jobs.jotta = {
     enable = true;
-    repository = "rclone:Jotta:1d444f272fa766893d9a06cc4d392cd5";
+    repository = "rest:http://127.0.0.1:56900/1d444f272fa766893d9a06cc4d392cd5";
     secret = "restic-core-tjoda-token";
     inherit paths;
     # rclone to Jottacloud: reading pack data costs egress and takes forever;
@@ -28,5 +28,12 @@ in {
       args = [];
       interval = "monthly";
     };
+  };
+
+  # The backup dials the proxy on this host; order after it so the
+  # boot-time Persistent timer run doesn't fail and page ServiceFailed.
+  systemd.services.restic-backups-jotta = {
+    after = ["rclone-jotta.service"];
+    wants = ["rclone-jotta.service"];
   };
 }

--- a/machines/dev.ldn/restic.nix
+++ b/machines/dev.ldn/restic.nix
@@ -13,5 +13,19 @@ in {
   services.restic.jobs = {
     tjoda = mkJob "tjoda";
     ldn = mkJob "ldn";
+    # Offsite via the Jotta proxy on core.tjoda (no Jotta credentials here).
+    # targetHost is the opaque repo name on Jotta — house convention, nothing
+    # host-identifying on the provider side.
+    jotta =
+      mkJob "jotta"
+      // {
+        targetHost = "24265df668ee1063b968320aa77677cf";
+        # Jotta egress is paid/slow: verify metadata only, monthly. The REST
+        # repos get the read-data checks.
+        check = {
+          args = [];
+          interval = "monthly";
+        };
+      };
   };
 }

--- a/machines/dev.oracfurt/restic.nix
+++ b/machines/dev.oracfurt/restic.nix
@@ -16,5 +16,19 @@ in {
   services.restic.jobs = {
     tjoda = mkJob "tjoda";
     ldn = mkJob "ldn";
+    # Offsite via the Jotta proxy on core.tjoda (no Jotta credentials here).
+    # targetHost is the opaque repo name on Jotta — house convention, nothing
+    # host-identifying on the provider side.
+    jotta =
+      mkJob "jotta"
+      // {
+        targetHost = "531e044d80bba9c63ec9d1ff2dd12c96";
+        # Jotta egress is paid/slow: verify metadata only, monthly. The REST
+        # repos get the read-data checks.
+        check = {
+          args = [];
+          interval = "monthly";
+        };
+      };
   };
 }

--- a/machines/home.ldn/restic.nix
+++ b/machines/home.ldn/restic.nix
@@ -17,5 +17,19 @@ in {
   services.restic.jobs = {
     tjoda = mkJob "tjoda";
     ldn = mkJob "ldn";
+    # Offsite via the Jotta proxy on core.tjoda (no Jotta credentials here).
+    # targetHost is the opaque repo name on Jotta — house convention, nothing
+    # host-identifying on the provider side.
+    jotta =
+      mkJob "jotta"
+      // {
+        targetHost = "bd1468c246bc9f509f8f423c32e86811";
+        # Jotta egress is paid/slow: verify metadata only, monthly. The REST
+        # repos get the read-data checks.
+        check = {
+          args = [];
+          interval = "monthly";
+        };
+      };
   };
 }


### PR DESCRIPTION
Jottacloud logins cannot be automated (single-use minutes-lived tokens, rotating refresh tokens — see 3c06d130), so every host holding its own login does not scale. Instead core.tjoda runs `rclone serve restic` fronting the Jotta remote as VIP `restic-jotta`: one token family, owned by a dedicated user with a persistent writable config, and the rest of the fleet backs up offsite over plain restic REST with no Jotta credentials.

core.oracldn, home.ldn, dev.ldn and dev.oracfurt gain `site = "jotta"` jobs with scrambled repo names, metadata-only monthly checks (pack reads cost egress). core.tjoda's own jotta job moves onto the proxy over localhost — same repo, no reupload; root's login is *moved* into the proxy's state dir (a move keeps the token family alive), making the proxy the host's only Jotta credential. storage.ldn keeps its direct login — its bulk traffic should not transit tjoda's uplink.

Local rest-servers stay: `rclone serve restic` verified worse for local disk (no upload hash verification, no per-repo metrics — rclone#7980, append-only retry defect — rclone#8958).

Monitoring: VIP blackbox probe, rclone metrics scrape, alerts for proxy-down / no-traffic-in-26h / metric-rename canary, all promtool-tested. Client jobs ride the existing `repo="jotta"` staleness rules; a daily `rclone lsd` health check pages on invalid_grant via `ServiceFailed`.

Companion change in `infrastructure` (committed, not applied): `svc:restic-jotta` + grants for `tag:server` and `tag:monitoring` incl. `tcp:56901`.

Deploy: apply infrastructure → deploy core.tjoda → `mkdir -p /var/lib/rclone-jotta && mv /root/.config/rclone/rclone.conf /var/lib/rclone-jotta/rclone.conf && chown -R rclone-jotta: /var/lib/rclone-jotta` (move, not copy — keeps the token family) → restart rclone-jotta → roll out clients.

> Generated with the help of an AI assistant
