### PR TITLE
tailscale: align advertised tags with granular ACL + IoT route

### DIFF
--- a/common/incus-vm-ldn.nix
+++ b/common/incus-vm-ldn.nix
@@ -13,8 +13,11 @@
     };
   };
 
+  # Baseline for ldn incus VMs; per-machine role tags merge on top. Location
+  # tags dropped (nothing keys off them). Authoritative assignment is in
+  # infrastructure/tailscale/device_tags.tf — this is only the advertise-on-up.
   services.tailscale = {
-    tags = ["tag:ldn" "tag:server"];
+    tags = ["tag:server"];
   };
 
   system.stateVersion = "24.05";

--- a/machines/core.oracldn/default.nix
+++ b/machines/core.oracldn/default.nix
@@ -124,7 +124,7 @@
 
   services.tailscale = {
     advertiseRoutes = ["10.66.0.0/16"];
-    tags = ["tag:oracldn" "tag:gateway" "tag:server"];
+    tags = ["tag:backup-client" "tag:gateway" "tag:monitoring" "tag:server"];
   };
 
   # This value determines the NixOS release from which the default

--- a/machines/core.terra/default.nix
+++ b/machines/core.terra/default.nix
@@ -159,7 +159,7 @@
 
   services.tailscale = {
     advertiseRoutes = ["10.60.0.0/16" "2a03:94e0:200d::/48"];
-    tags = ["tag:terra" "tag:gateway" "tag:server"];
+    tags = ["tag:gateway" "tag:server" "tag:storage"];
   };
 
   # TODO: Fix disk monitoring somehow

--- a/machines/core.tjoda/default.nix
+++ b/machines/core.tjoda/default.nix
@@ -87,7 +87,7 @@
 
   services.tailscale = {
     advertiseRoutes = ["10.62.0.0/16"];
-    tags = ["tag:tjoda" "tag:gateway" "tag:server"];
+    tags = ["tag:backup-client" "tag:gateway" "tag:server" "tag:storage"];
   };
 
   age.secrets.headscale-sfiber-authkey = {

--- a/machines/dev.ldn/default.nix
+++ b/machines/dev.ldn/default.nix
@@ -77,7 +77,10 @@ in {
   users.users.kradalby.linger = true;
 
   services.tailscale = {
-    advertiseRoutes = ["10.65.0.0/16" "2a02:6b66:7019::/64"];
+    # 192.168.156.0/24 = the IoT VLAN (unifi vlan 156); routed here so
+    # core.oracldn's tasmota/homewizard exporters can reach *.ldn devices.
+    # Needs the unifi LAN->IoT firewall to permit the probe.
+    advertiseRoutes = ["10.65.0.0/16" "192.168.156.0/24" "2a02:6b66:7019::/64"];
     # tag:server comes from the incus-vm-ldn.nix baseline.
     tags = ["tag:backup-client" "tag:deployer" "tag:dev" "tag:gateway"];
   };

--- a/machines/dev.ldn/default.nix
+++ b/machines/dev.ldn/default.nix
@@ -78,7 +78,8 @@ in {
 
   services.tailscale = {
     advertiseRoutes = ["10.65.0.0/16" "2a02:6b66:7019::/64"];
-    tags = ["tag:ldn" "tag:gateway" "tag:server"];
+    # tag:server comes from the incus-vm-ldn.nix baseline.
+    tags = ["tag:backup-client" "tag:deployer" "tag:dev" "tag:gateway"];
   };
 
   # Secondary Tailscale instance: headscale.sandefjordfiber.no (dev.ldn only).

--- a/machines/dev.oracfurt/default.nix
+++ b/machines/dev.oracfurt/default.nix
@@ -101,7 +101,7 @@
 
   services.tailscale = {
     advertiseRoutes = ["10.67.0.0/16"];
-    tags = ["tag:oracfurt" "tag:gateway" "tag:server"];
+    tags = ["tag:backup-client" "tag:dev" "tag:gateway" "tag:server"];
   };
 
   services.tsidp.enable = true;

--- a/machines/gigabuilder/default.nix
+++ b/machines/gigabuilder/default.nix
@@ -51,7 +51,7 @@
 
   services.tailscale = {
     advertiseRoutes = ["10.68.0.0/16"]; # the VM subnet
-    tags = ["tag:server" "tag:builder" "tag:incus"];
+    tags = ["tag:builder" "tag:incus" "tag:server" "tag:smtp"];
   };
 
   # Trust the VM bridge; open 41641 so tailscale connects directly, not via DERP.

--- a/machines/home.ldn/default.nix
+++ b/machines/home.ldn/default.nix
@@ -23,6 +23,10 @@
     ./owntone.nix
   ];
 
+  # Merges with the tag:server baseline from incus-vm-ldn.nix. tag:homeauto
+  # gates the mqtt ports and approves the owntone/p3/z2m VIP advertisements.
+  services.tailscale.tags = ["tag:backup-client" "tag:homeauto"];
+
   networking = {
     hostName = "home";
     interfaces."${config.my.lan}" = {

--- a/machines/lenovo.ldn/default.nix
+++ b/machines/lenovo.ldn/default.nix
@@ -22,7 +22,7 @@
   };
 
   services.tailscale = {
-    tags = ["tag:ldn" "tag:server"];
+    tags = ["tag:server"];
   };
 
   virtualisation.docker.enable = lib.mkForce false;

--- a/machines/rpi5.ldn/default.nix
+++ b/machines/rpi5.ldn/default.nix
@@ -39,7 +39,7 @@
 
   age.secrets.ldn-wifi.file = ../../secrets/ldn-wifi.age;
 
-  services.tailscale.tags = ["tag:ldn" "tag:server"];
+  services.tailscale.tags = ["tag:server"];
 
   # nixos-raspberrypi is migrating the default from "kernelboot" to
   # "kernel"; opt in explicitly to silence the deprecation warning.

--- a/machines/storage.ldn/default.nix
+++ b/machines/storage.ldn/default.nix
@@ -28,6 +28,8 @@ in {
   };
 
   services.tailscale.advertiseRoutes = ["10.65.0.0/24"];
+  # Merges with the tag:server baseline from incus-vm-ldn.nix.
+  services.tailscale.tags = ["tag:backup-client" "tag:storage"];
 
   networking = {
     hostName = "storage";


### PR DESCRIPTION
Companion to infrastructure#5 (the granular Tailscale ACL). No deploy required for the tag changes — device_tags.tf is authoritative; these keep the declared advertise-tags honest.

- Align `services.tailscale.tags` to the new scheme: drop location tags from the incus-vm-ldn baseline; add role tags per machine (backup-client/deployer/dev/monitoring/storage/homeauto/smtp).
- dev.ldn advertises the IoT VLAN (192.168.156.0/24) so core.oracldn's tasmota/homewizard exporters can probe it (needs a deploy + unifi LAN→IoT firewall to route).

Verified via `nix eval` — merged tag sets correct for all server configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)