### PR TITLE
monitoring: fix the alert storm root causes

### DIFF
--- a/machines/core.oracldn/monitoring.nix
+++ b/machines/core.oracldn/monitoring.nix
@@ -135,9 +135,13 @@
           preferred_ip_protocol: ip4
   '';
 
-  # Filesystem filter for disk alerts — excludes virtual, boot, and
-  # Incus filesystems. Incus hosts have dedicated alerts.
-  diskFilter = ''fstype!~"(tmpfs|ramfs)",mountpoint!~"^/boot.?/?.*",role!="incus"'';
+  # Filesystem filter for disk alerts — excludes virtual, boot, and Incus
+  # filesystems. Incus guests have dedicated alerts (role="incus"), but the
+  # Incus *host* carries no role label, so two host-side mounts leak through and
+  # storm on every build spike: /var/lib/lxcfs (fuse.lxcfs always reports 0 free)
+  # and the per-VM /var/lib/incus/devices/*.mount config datasets (~500MB ZFS
+  # metadata, not the real VM disk). Exclude both by fstype and mountpoint.
+  diskFilter = ''fstype!~"(tmpfs|ramfs|fuse.lxcfs)",mountpoint!~"^/boot.?/?.*",mountpoint!~"^/var/lib/incus/devices/.*",role!="incus"'';
 
   # Every job carries a port-free "host" label so Alertmanager can group and
   # inhibit per machine; the instance label includes the port, which made the

--- a/machines/core.oracldn/monitoring.nix
+++ b/machines/core.oracldn/monitoring.nix
@@ -475,11 +475,25 @@ in {
         "http://restic-jotta.dalby.ts.net"
       ])
 
-      (probeJob "dns-probes" "dns" [
-        "10.66.0.1"
-        "10.62.0.2"
-        "10.65.0.28"
-      ])
+      # Per-site labels so a resolver-down alert can inhibit that site's
+      # downstream name-resolution-dependent probes (see inhibit_rules).
+      ((probeJob "dns-probes" "dns" [])
+        // {
+          static_configs = [
+            {
+              targets = ["10.66.0.1"];
+              labels.site = "oracldn";
+            }
+            {
+              targets = ["10.62.0.2"];
+              labels.site = "tjoda";
+            }
+            {
+              targets = ["10.65.0.28"];
+              labels.site = "ldn";
+            }
+          ];
+        })
       (probeJob "tcp-probes" "tcp_connect" [
         "proton-bridge:143"
         "core-tjoda:445"
@@ -544,6 +558,10 @@ in {
         };
         static_configs = [
           {
+            # site label lets a tjoda-resolver DnsProbeDown inhibit this whole
+            # job — the targets are *.tjoda.fap.no and can't resolve when the
+            # resolver is unreachable, so the pings fail as a downstream effect.
+            labels.site = "tjoda";
             targets = [
               # Unifi
               "hus-kontor-printer.tjoda.fap.no"
@@ -1948,6 +1966,15 @@ in {
             source_matchers = ["severity=\"critical\""];
             target_matchers = ["severity=\"warning\""];
             equal = ["alertname" "host"];
+          }
+          {
+            # A resolver being unreachable (DnsProbeDown) makes every ICMP probe
+            # for names in that site fail too — they can't resolve. Suppress the
+            # per-device flood (e.g. 13× TjodaPingDown) and page once on the
+            # resolver. Matches on the shared "site" label set on both jobs.
+            source_matchers = ["alertname=\"DnsProbeDown\""];
+            target_matchers = ["alertname=\"TjodaPingDown\""];
+            equal = ["site"];
           }
         ];
 

--- a/machines/core.oracldn/monitoring.nix
+++ b/machines/core.oracldn/monitoring.nix
@@ -419,11 +419,13 @@ in {
       ])
 
       # golink: note the leading dot in the path; https with a ts.net cert.
+      # Full FQDN target so the ts.net cert validates (the cert is for
+      # go.dalby.ts.net; the bare "go" name failed x509 SAN verification).
       {
         job_name = "golink";
         scheme = "https";
         metrics_path = "/.metrics";
-        static_configs = [{targets = ["go:443"];}];
+        static_configs = [{targets = ["go.dalby.ts.net:443"];}];
         relabel_configs = [hostRelabel];
       }
 


### PR DESCRIPTION
Root-cause fixes for the 2026-07-10 alert storm. All rolled out to core.oracldn and verified live before merge.

- **Disk false positive**: exclude `fuse.lxcfs` (always 0 free) and the incus per-VM device mounts from `diskFilter` — they stormed `InstanceLowDiskAbs` on every build spike. *(verified: alert resolved)*
- **golink**: scrape via `go.dalby.ts.net:443` so the ts.net cert validates (bare `go` hit an x509 SAN mismatch). *(verified: up=1)*
- **Fatigue**: `site` labels on `dns-probes`/`tjoda-ping` + inhibit `TjodaPingDown` when that site's `DnsProbeDown` fires — a dead resolver made every name-based probe fail, so page once, not 14×.

The DNS storm itself was an ACL `:53` gap + an Apple-TV route hijack (fixed in the infrastructure repo / tailnet admin), not a monitoring change.