### PR TITLE
tsnixcache: add a config-as-code Grafana dashboard

### DIFF
--- a/docs/conventions/README.md
+++ b/docs/conventions/README.md
@@ -8,6 +8,7 @@ Starting a new project? Read this file, then the file for your stack.
 - **Refresh before building.** This guide goes stale. Before starting, check the newest toolchain/language release and its notes, the relevant upstream (nixpkgs & `lib`, stdlib, framework changelogs, project issues/forums), _and_ my freshest repo. Adopt new idioms and helpers; don't cargo-cult this file.
 - **Comments are terse and explain _why_, not _what_.**
 - **Nix-first.** Every repo has a `flake.nix`. Build/test/lint/format are flake outputs, not ad-hoc scripts.
+- **Ship the tool and its output.** A binary that generates an artifact exposes both the CLI package and a derivation of its built output; consumers choose Nix or not. → [nix.md](nix.md)
 - **All checks go through [`kradalby/flake-checks`](https://github.com/kradalby/flake-checks).** Extend it, don't fork the pattern. CI just calls the checks. → [nix.md](nix.md)
 - **Formatting: treefmt, always.** One entrypoint orchestrating every language's formatter (nixfmt-rfc-style, gofumpt + goimports, prettier, shfmt) — no standalone per-tool hooks, no per-repo formatter drift. → [nix.md](nix.md)
 - **prek** runs format+lint hooks (`treefmt --fail-on-change` for formatting); `prek run --all-files` before commit. → [git.md](git.md)

--- a/docs/conventions/nix.md
+++ b/docs/conventions/nix.md
@@ -41,6 +41,33 @@ in {
 - Expose `overlays.default`, and for services `nixosModules.default`.
 - Flake apps for ergonomics: `nix run .#test` / `.#test-race` / `.#lint` / `.#coverage`. (z2m-homekit)
 
+## Generated artifacts (ship the tool _and_ its output)
+
+A binary whose job is to emit an artifact (dashboard JSON, config, schema,
+codegen, docs) exposes **two** flake outputs: the CLI, and a derivation that
+runs it and captures only the output.
+
+```nix
+# 1. the tool — for humans / non-Nix consumers (`nix run .#dashboard`)
+dashboard = fc.goBuild (common // {
+  pname       = "myapp-dashboard";
+  subPackages = [ "cmd/dashboard" ];              # own build; keeps SDK deps
+});                                                #   out of the service binary
+
+# 2. the built artifact — for Nix consumers to depend on directly.
+#    Build() validates, so a bad artifact fails here instead of shipping.
+grafanaDashboards = pkgs.runCommand "myapp-grafana-dashboards" { } ''
+  mkdir -p $out
+  ${dashboard}/bin/dashboard > $out/myapp.json
+'';
+
+packages = { inherit dashboard grafanaDashboards; default = app; };
+```
+
+- **Generator lives beside what it describes.** Source and artifact move together — one bump updates both, no hand-edited output, no drift. (tsnixcache: the Grafana dashboard is generated next to the metrics it charts.)
+- **Consumers pick their level.** Run the CLI (no Nix), or reference `${x.packages.<sys>.grafanaDashboards}/…` from a `runCommand`/module. A downstream flake gets the artifact through its existing input — no extra fetch.
+- **Validation is the build.** The emit path is pure and deterministic (stdout or a file arg) and exits non-zero on a bad artifact, so the derivation fails rather than ships. (tsnixcache: `cmd/dashboard` → `grafanaDashboards`.)
+
 ## vendorHash churn → flakehashes.json
 
 Hashes that change often live in a root `flakehashes.json`, read with
@@ -91,7 +118,7 @@ Prefer nix-built images (`dockerTools.buildLayeredImage`); fall back to a multi-
 
 ## Copy from
 
-- `tsnixcache` `flake.nix` + `nix/module-{server,client}.nix` + `nix/tests/*.nix` — freshest full example
+- `tsnixcache` `flake.nix` + `nix/module-{server,client}.nix` + `nix/tests/*.nix` — freshest full example; `cmd/dashboard` + `grafanaDashboards` — the ship-tool-and-output pattern
 - `z2m-homekit/flake.nix` + `z2m-homekit/nix/module.nix` — modern flake + module + CI
 - `kra/flake.nix` — minimal flake-checks wiring
 - `headscale/flake.nix` — full (overlay, module, flakehashes, docker)

--- a/flake.lock
+++ b/flake.lock
@@ -2009,11 +2009,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784008769,
-        "narHash": "sha256-S5Fbf8vzclREzayKIH9+8yK5u3ld6QlzdqZmcdgPQQc=",
+        "lastModified": 1784362057,
+        "narHash": "sha256-oshGNYy92HzUrtXKnjC7U7cFMEw27nTsfwULQCrDKfA=",
         "owner": "kradalby",
         "repo": "tsnixcache",
-        "rev": "58c756a0f0b7e7a3fb4887b5ef0a75fd166a9183",
+        "rev": "27fbf7efab3422e37cdeccff6a313b02a056149a",
         "type": "github"
       },
       "original": {

--- a/machines/core.oracldn/default.nix
+++ b/machines/core.oracldn/default.nix
@@ -13,7 +13,6 @@
     ../../common/containers.nix
 
     ../../common/coredns.nix
-    ../../common/miniupnp.nix
     ../../common/tailscale.nix
     ../../common/tsnixcache-client.nix
 

--- a/machines/core.oracldn/grafana.nix
+++ b/machines/core.oracldn/grafana.nix
@@ -1,4 +1,5 @@
 {
+  inputs,
   pkgs,
   lib,
   config,
@@ -39,6 +40,12 @@ let
         name = "incus.json";
       }
     } $out/incus.json
+
+    # tsnixcache dashboard, generated from Go (Foundation SDK) in the tsnixcache
+    # repo and shipped as a flake package, so it tracks the metrics it charts.
+    cp ${
+      inputs.tsnixcache.packages.${pkgs.stdenv.hostPlatform.system}.grafanaDashboards
+    }/tsnixcache.json $out/tsnixcache.json
   '';
 in
 {


### PR DESCRIPTION
Bump `tsnixcache` for the `nar_bytes_received_total` metric — cache bandwidth (served vs received) is finally measurable — plus the per-batch watch throughput logging.

The dashboard is generated in the `tsnixcache` repo from Go (Grafana Foundation SDK) and shipped as a flake output, so panels and metrics move together: a metric change and its chart land in one bump, no hand-edited JSON, no drift. It targets a `$datasource` variable, so it stays portable to any Grafana scraping tsnixcache. Provisioned through the existing `community` file provider on `core.oracldn` — no new wiring.

Also drops `miniupnpd` on `core.oracldn`. It can't start on an Oracle cloud VM (no iptables modules) and a cloud host has no UPnP to manage, yet its failure made `switch-to-configuration` exit 4 and every deploy report as failed. `core.terra` keeps it.

> Generated with the help of an AI assistant
