### PR TITLE
garnix: add dev.oracfurt as aarch64 builder

### DIFF
--- a/common/garnix-build-target.nix
+++ b/common/garnix-build-target.nix
@@ -1,0 +1,24 @@
+# Be a remote nix build target for the self-hosted garnix VM (machines/garnix):
+# garnix offloads realisation here over SSH as nix-ssh, builds in the sandbox,
+# and the tsnixcache watch client pushes the outputs to the cache. Imported by
+# gigabuilder (x86_64, reached over incusbr0) and dev.oracfurt (aarch64, over
+# the tailnet). Single source for the trusted builder key so it can't drift.
+{
+  pkgs,
+  config,
+  ...
+}:
+{
+  users.groups.nix-ssh = { };
+  users.users.nix-ssh = {
+    isSystemUser = true;
+    group = "nix-ssh";
+    shell = "${pkgs.bashInteractive}/bin/bash"; # forced command runs via $SHELL -c; nologin breaks it
+    # Pin the key to the nix-daemon protocol only. nix-ssh is still a trusted nix
+    # user (a remote builder must be), so this caps SSH surface, not the reach.
+    openssh.authorizedKeys.keys = [
+      "command=\"${config.nix.package}/bin/nix-daemon --stdio\",restrict ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB/gPdHyIXk4sq1+ZskMFEt2Kn1IDQU0k9sTolwl4UA2 garnix-remote-builder"
+    ];
+  };
+  nix.settings.trusted-users = [ "nix-ssh" ];
+}

--- a/machines/dev.oracfurt/default.nix
+++ b/machines/dev.oracfurt/default.nix
@@ -14,6 +14,7 @@
     ../../common/tailscale.nix
     ../../common/tsnixcache-client.nix
 
+    ./garnix-builder.nix
     ./restic.nix
     ./syncthing.nix
     ./proton.nix

--- a/machines/dev.oracfurt/garnix-builder.nix
+++ b/machines/dev.oracfurt/garnix-builder.nix
@@ -1,0 +1,19 @@
+# dev.oracfurt as the garnix VM's aarch64 remote builder. garnix's fleet is
+# otherwise x86_64-only (gigabuilder), so its Oracle/rpi nixosConfig checks had
+# no aarch64 builder and never built. This host is native aarch64 and near-idle.
+#
+# Reached over the tailnet, but Tailscale SSH owns tailnet :22 and authenticates
+# by tailnet identity — it never consults the nix-ssh authorized_keys, so the
+# forced-command build key can't work there. Run a second sshd port that
+# tailscale-ssh does not intercept (only :22) and point garnix at it.
+{ ... }:
+{
+  imports = [ ../../common/garnix-build-target.nix ];
+
+  services.openssh.ports = [
+    22
+    2222
+  ];
+  # Only the tailnet reaches the build port; never the WAN.
+  networking.firewall.interfaces.tailscale0.allowedTCPPorts = [ 2222 ];
+}

--- a/machines/garnix/default.nix
+++ b/machines/garnix/default.nix
@@ -149,6 +149,20 @@ in
           "nixos-test"
         ];
       }
+      {
+        # Native aarch64 builder (Ampere), so the Oracle/rpi nixosConfig checks
+        # finally build instead of failing "no aarch64 builder". Reached over the
+        # tailnet on a non-22 port (see Port pin below + dev.oracfurt/garnix-
+        # builder.nix). maxJobs 1: small VM, and these are infrequent PR builds.
+        # No kvm/nixos-test — Ampere has no /dev/kvm.
+        name = "dev-oracfurt";
+        hostname = "dev-oracfurt.dalby.ts.net";
+        user = "nix-ssh";
+        systems = [ "aarch64-linux" ];
+        maxJobs = 1;
+        speedFactor = 2;
+        supportedFeatures = [ "big-parallel" ];
+      }
     ];
 
     # Outputs already land in gigabuilder's tsnixcache-served store.
@@ -189,6 +203,18 @@ in
       "10.68.0.1"
     ];
     publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIfxql6LaBrlxvBDywHRWULRocO9Yo57DlrlsdDCkcis";
+  };
+
+  # dev-oracfurt's build sshd is on :2222 (tailnet :22 is Tailscale SSH). garnix
+  # emits the Host alias without a Port, so pin it — ssh merges keywords across
+  # matching Host blocks, taking the Port from here and the rest from garnix.
+  programs.ssh.extraConfig = ''
+    Host dev-oracfurt
+      Port 2222
+  '';
+  programs.ssh.knownHosts.dev-oracfurt = {
+    hostNames = [ "[dev-oracfurt.dalby.ts.net]:2222" ];
+    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE65s/hRn34v5UNhSIC8/JN/452hLdqn131gVqqBTPnl";
   };
 
   # Loopback-only datastores, so peer/trust auth and no TLS — the fork's own

--- a/machines/gigabuilder/builder.nix
+++ b/machines/gigabuilder/builder.nix
@@ -1,24 +1,10 @@
+{ ... }:
 {
-  pkgs,
-  config,
-  ...
-}:
-{
-  # gigabuilder as the garnix VM's remote nix builder: it offloads realisation
-  # here over SSH (incusbr0 is trusted, so no extra firewall rule), builds in the
-  # sandbox, and populates the host store tsnixcache serves.
-  users.groups.nix-ssh = { };
-  users.users.nix-ssh = {
-    isSystemUser = true;
-    group = "nix-ssh";
-    shell = "${pkgs.bashInteractive}/bin/bash"; # forced command runs via $SHELL -c; nologin breaks it
-    # Pin the key to the nix-daemon protocol only. nix-ssh is still a trusted nix
-    # user (a remote builder must be), so this caps SSH surface, not the reach.
-    openssh.authorizedKeys.keys = [
-      "command=\"${config.nix.package}/bin/nix-daemon --stdio\",restrict ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB/gPdHyIXk4sq1+ZskMFEt2Kn1IDQU0k9sTolwl4UA2 garnix-remote-builder"
-    ];
-  };
-  nix.settings.trusted-users = [ "nix-ssh" ];
+  # gigabuilder as the garnix VM's remote x86_64 nix builder: it offloads
+  # realisation here over SSH (incusbr0 is trusted, so no extra firewall rule),
+  # builds in the sandbox, and populates the host store tsnixcache serves. The
+  # nix-ssh build user + trusted key are shared with dev.oracfurt (aarch64).
+  imports = [ ../../common/garnix-build-target.nix ];
 
   # Confine builds to cores 4-31, leaving 0-3 for the co-located garnix VM
   # (pinned there in ~/git/infrastructure). Without this, offloaded builds starve


### PR DESCRIPTION
garnix's self-hosted fleet is x86_64-only (gigabuilder), so every aarch64 nixosConfig check (`core-oracldn`, `dev-oracfurt`, `rpi5-ldn`) fails with no builder and never actually builds — perpetually red, masking real failures.

Add `dev.oracfurt` (native Ampere aarch64, near-idle) as garnix's aarch64 builder. It's reached over the tailnet, but Tailscale SSH owns tailnet `:22` and ignores `authorized_keys`, so the nix-ssh forced-command build key runs on a second sshd port (`:2222`) that tailscale-ssh doesn't intercept — gigabuilder avoids this only because it's reached over incusbr0. The nix-ssh builder user is factored into `common/garnix-build-target.nix` so both builders share one source of the trusted key. `maxJobs 1`, `big-parallel` only (Ampere has no `/dev/kvm`).

Needs the paired tailnet ACL grant (`garnix → dev-oracfurt:2222`, infrastructure repo) and deploy order: dev.oracfurt + ACL before garnix.

> Generated with the help of an AI assistant