### PR TITLE
machines/garnix: bound build concurrency, reconcile orphaned builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -599,11 +599,11 @@
         "treetop": "treetop"
       },
       "locked": {
-        "lastModified": 1783698817,
-        "narHash": "sha256-ydiGekLsoKjITJOqiGuk0Crl4plwk8ZtuUskigzB27k=",
+        "lastModified": 1784472738,
+        "narHash": "sha256-bBW8sKVp51uVGURzo5L7ykuOzU3m0ecRqjUqVOGe9o4=",
         "owner": "kradalby",
         "repo": "garnix",
-        "rev": "15c538c611c599b470c8f9fbbc4970b07c8735c9",
+        "rev": "010e13e0ac65345d73b180152511add614f19f19",
         "type": "github"
       },
       "original": {

--- a/machines/garnix/README.md
+++ b/machines/garnix/README.md
@@ -63,13 +63,30 @@ garnix hard-codes SaaS-sized concurrency; on the 16 GiB VM a big repo (headscale
 kills OpenSearch and nix. The fork makes the pools env-configurable — set in
 `default.nix`: `GARNIX_NIX_EVAL_POOL_SIZE = "6"`, `GARNIX_FOD_CHECK_POOL_SIZE = "4"`.
 Keep the VM at 16 GiB; gigabuilder needs its 64 GiB for the offloaded builds.
+`services.systemd` OOMScoreAdjust (garnixServer `+500`, postgres/opensearch `-800`)
+makes garnix's own tree the OOM victim instead of the datastores.
+
+### Build concurrency / starvation
+
+Realisation used to be unbounded: every attribute of a flake fired `nix build` at
+once, and because the build timeout wrapped the *queue wait*, a big push left tail
+builds spuriously timing out while they waited for a slot (→ repush → worse). The
+fork adds a build-dispatch pool acquired *outside* the timeout; set in `default.nix`:
+`GARNIX_NIX_BUILD_POOL_SIZE = "8"`, kept in step with the gigabuilder remote-builder
+`maxJobs = 8` (8 × 4 cores/job ≈ the 28 build cores). Backlogged builds now wait
+untimed instead of failing. Raise both together if gigabuilder grows.
 
 ### Queue / reset
 
 State is postgres db `garnix`. `builds.status` is an enum, `NULL` = pending. garnix
-does **not** resume orphaned pending builds after a crash, and never rebuilds
-_superseded_ commits — their GitHub checks sit `in_progress` forever (harmless; the
-PR uses the latest commit). Reset the queue with SQL on `builds`:
+does **not** resume orphaned pending builds after a crash — but the fork now runs a
+**startup reconciler** (`Garnix.Reconcile.reconcileOrphanedBuilds`, called before
+webhooks are served) that, for every still-`NULL` build, first **closes its GitHub
+check run** (best-effort — bounded one-shot, so not the crash-loop that trips the 403
+secondary limit) so a PR no longer hangs on a forever-spinning required check, then
+marks it `cancelled` in the DB. A restart thus self-heals without a repush. garnix
+still never rebuilds _superseded_ commits; their checks sit `in_progress` forever
+(harmless; the PR uses the latest commit). Manual reset is still SQL on `builds`:
 
 ```bash
 incus exec gigabuilder:garnix -- bash -lc "sudo -u postgres psql -d garnix"

--- a/machines/garnix/default.nix
+++ b/machines/garnix/default.nix
@@ -148,7 +148,10 @@ in
         hostname = "10.68.0.1"; # host over incusbr0 (a trustedInterface)
         user = "nix-ssh";
         systems = [ "x86_64-linux" ];
-        maxJobs = 16;
+        # Kept in step with GARNIX_NIX_BUILD_POOL_SIZE above: no point letting the
+        # nix-daemon dispatch more concurrent builds than the coordinator pool
+        # admits. 8 × 4 cores/job ≈ the 28 build cores (4-31) on gigabuilder.
+        maxJobs = 8;
         speedFactor = 4;
         supportedFeatures = [
           "big-parallel"
@@ -198,10 +201,27 @@ in
     # out ~50 evals at ~0.5 GiB each); cap them. Raise if the VM grows.
     GARNIX_NIX_EVAL_POOL_SIZE = "6";
     GARNIX_FOD_CHECK_POOL_SIZE = "4";
+    # Cap concurrent `nix build` dispatch (fork feature). Previously unbounded —
+    # every attribute of a flake fired `nix build` at once, oversubscribing the
+    # builder and (because the build timeout wrapped the queue wait) making
+    # backlogged builds spuriously time out. 8 ≈ gigabuilder's 28 build cores /
+    # 4 cores-per-job; the maxJobs below is kept in step. Builds beyond 8 queue
+    # untimed rather than starving.
+    GARNIX_NIX_BUILD_POOL_SIZE = "8";
     # Owner allowlist (fork feature): upstream gates only by denylist, so an
     # internet-facing App builds for anyone who installs it. Unset ⇒ allow all.
     GARNIX_ALLOWED_OWNERS = "kradalby,juanfont";
   };
+
+  # OOM containment. eval/build subprocesses inherit garnixServer's oom_score_adj,
+  # so a memory spike there makes garnix's own tree the kernel's preferred victim
+  # rather than the datastores — which it has historically killed (OpenSearch/
+  # postgres down = the #1 documented outage). If garnixServer itself is reaped,
+  # Restart=always brings it back and the startup reconciler clears any builds
+  # orphaned by the kill.
+  systemd.services.garnixServer.serviceConfig.OOMScoreAdjust = 500;
+  systemd.services.postgresql.serviceConfig.OOMScoreAdjust = -800;
+  systemd.services.opensearch.serviceConfig.OOMScoreAdjust = -800;
 
   # Pre-trust the builder's host key, else nix's non-interactive SSH to it fails.
   programs.ssh.knownHosts.gigabuilder = {


### PR DESCRIPTION
Self-hosted garnix stalled under load: `runBuildFlake` dispatched a `nix build` for every flake attribute at once with no pool around realisation, and the build timeout wrapped the queue wait — so a large push left backlogged builds burning their timeout budget waiting for a slot and failing as `Timeout`, prompting repushes and a starvation spiral. A coordinator restart left in-flight builds pending forever with their GitHub checks spinning.

The backend fix (`garnix-ci` bumped to `010e13e`) adds an owner-fair build-dispatch pool acquired *outside* the timeout, so backlogged builds wait untimed and only start the clock once they hold a slot, plus a startup reconciler that closes orphaned builds' GitHub check runs and marks them cancelled — a restart self-heals without a repush.

Here: `GARNIX_NIX_BUILD_POOL_SIZE=8` matched to gigabuilder `maxJobs`, and `OOMScoreAdjust` so an eval/build memory spike kills garnix's tree rather than `postgres`/`opensearch` (the documented outage).

Not yet deployed; needs `colmena apply --on garnix`, which forces a backend recompile.

> Generated with the help of an AI assistant