### PR TITLE
flake.lock: fix garnix reconciler startup crash-loop

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -599,11 +599,11 @@
         "treetop": "treetop"
       },
       "locked": {
-        "lastModified": 1784472738,
-        "narHash": "sha256-bBW8sKVp51uVGURzo5L7ykuOzU3m0ecRqjUqVOGe9o4=",
+        "lastModified": 1784484583,
+        "narHash": "sha256-ZYXCDPkCwbyicDVROC3s0iA6hGJK2rNuuRR1SF8nQBE=",
         "owner": "kradalby",
         "repo": "garnix",
-        "rev": "010e13e0ac65345d73b180152511add614f19f19",
+        "rev": "e51a03d181affba597f451be7cd15608892f0ca3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Follow-up to #51. That reconciler closed the GitHub check of *every* historical `status IS NULL` build synchronously before the server opened its port — on garnix that was ~2100 orphans, so startup blew the 90s systemd timeout and `garnixServer` crash-looped, re-issuing the whole GitHub burst each restart.

Bumps `garnix-ci` to `e51a03d`: the DB cancel stays synchronous (one fast `UPDATE`, pre-Warp), but the GitHub close is now bounded to recent check-bearing orphans (last 2h, capped) and runs in the background via `forkM`, so startup never blocks and the harmless historical backlog is left alone.

Already deployed to garnix and verified — `Startup reconciler: aborted 2101 orphaned build(s)` then `Listening on port 8321`, `active`, no restarts.

> Generated with the help of an AI assistant