### PR TITLE
machines: add kratail2 rosetta VM as a garnix aarch64 builder

### DIFF
--- a/machines/dev.oracfurt/default.nix
+++ b/machines/dev.oracfurt/default.nix
@@ -114,6 +114,10 @@
       "tag:dev"
       "tag:gateway"
       "tag:server"
+      # garnix aarch64 build target — see machines/garnix + the kradalby.no ACL
+      # (src tag:garnix -> dst tag:garnix-builder). Also the cache-push identity,
+      # so oracfurt no longer relies on tag:dev being in the tsnixcache push src.
+      "tag:garnix-builder"
     ];
   };
 

--- a/machines/garnix/default.nix
+++ b/machines/garnix/default.nix
@@ -114,9 +114,14 @@ in
     cleanOnBoot = true;
   };
 
-  # tag:server only — the shared preauth key isn't authorized for tag:ci, and
-  # tag:ci only grants attic (unused; garnix uses tsnixcache).
-  services.tailscale.tags = [ "tag:server" ];
+  # tag:server for the fleet's existing grants (smtp/s3/idp); tag:garnix is the
+  # dedicated identity for garnix's build-offload traffic, so the kradalby.no ACL
+  # can scope `src tag:garnix -> dst tag:garnix-builder` narrowly (see
+  # git/infrastructure/tailscale). tag:ci is unused (garnix uses tsnixcache).
+  services.tailscale.tags = [
+    "tag:server"
+    "tag:garnix"
+  ];
 
   services.garnixServer = {
     enable = true;
@@ -170,6 +175,23 @@ in
         speedFactor = 2;
         supportedFeatures = [ "big-parallel" ];
       }
+      {
+        # kratail2's rosetta-builder Lima VM: a fast native aarch64 builder on the
+        # tailnet, PREFERRED over dev.oracfurt (higher speedFactor) whenever the
+        # Mac is online. garnix does no scheduling — stock nix build-remote skips
+        # an unreachable machine to the next eligible one, so an offline Mac just
+        # falls back to dev.oracfurt (~5s, connect-timeout=5 from common/nix.nix +
+        # the ConnectTimeout pin below). The guest runs plain tailscale (no --ssh),
+        # so the nix-ssh forced-command build key works on :22 — no port pin.
+        # No kvm/nixos-test through the VM.
+        name = "rosetta-kratail2";
+        hostname = "rosetta-kratail2.dalby.ts.net";
+        user = "nix-ssh";
+        systems = [ "aarch64-linux" ];
+        maxJobs = 12; # VM cores
+        speedFactor = 5;
+        supportedFeatures = [ "big-parallel" ];
+      }
     ];
 
     # Outputs already land in gigabuilder's tsnixcache-served store.
@@ -215,13 +237,29 @@ in
   # dev-oracfurt's build sshd is on :2222 (tailnet :22 is Tailscale SSH). garnix
   # emits the Host alias without a Port, so pin it — ssh merges keywords across
   # matching Host blocks, taking the Port from here and the rest from garnix.
+  # rosetta-kratail2 uses plain :22 (no Tailscale SSH on the guest); pin a short
+  # ConnectTimeout so an offline Mac fails over to dev-oracfurt in ~5s regardless
+  # of whether nix's connect-timeout maps onto the builder ssh.
   programs.ssh.extraConfig = ''
     Host dev-oracfurt
       Port 2222
+    Host rosetta-kratail2
+      ConnectTimeout 5
   '';
   programs.ssh.knownHosts.dev-oracfurt = {
     hostNames = [ "[dev-oracfurt.dalby.ts.net]:2222" ];
     publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE65s/hRn34v5UNhSIC8/JN/452hLdqn131gVqqBTPnl";
+  };
+
+  # The guest sshd host key is generated when the Lima VM is (re)created, so it
+  # rotates on any config/image change to kratail2's rosetta-builder. Read it
+  # after provisioning from the Mac's working dir and paste it here:
+  #   /var/lib/rosetta-builder/ssh_host_ed25519_key.pub
+  # Refresh this whenever the VM is recreated (same caveat as dev-oracfurt).
+  # TODO(kradalby): fill in the guest host key after first `tailscale up`.
+  programs.ssh.knownHosts.rosetta-kratail2 = {
+    hostNames = [ "rosetta-kratail2.dalby.ts.net" ];
+    publicKey = "ssh-ed25519 AAAA_REPLACE_WITH_GUEST_HOST_KEY rosetta-kratail2";
   };
 
   # Loopback-only datastores, so peer/trust auth and no TLS — the fork's own

--- a/machines/kratail2/default.nix
+++ b/machines/kratail2/default.nix
@@ -3,6 +3,7 @@
   config,
   lib,
   pkgs,
+  inputs,
   ...
 }:
 let
@@ -50,13 +51,55 @@ in
   ];
 
   # kratail2 is a 16-core / 128 GB box, so give the linux builder more than the
-  # shared 8-core / 6 GiB default. onDemand: the VM powers off when idle and
-  # spins up on the first Linux build (a few seconds), reclaiming the RAM the
-  # rest of the time.
+  # shared 8-core / 6 GiB default. onDemand is OFF: the VM also serves garnix CI
+  # as an aarch64 builder over the tailnet (extra module below), and garnix can't
+  # trigger the Mac-local on-demand wake — it only reaches the VM's tailnet IP
+  # when the VM is already up. Always-on keeps it reliably present so garnix
+  # prefers it over dev.oracfurt; when the Mac is off the node drops off the
+  # tailnet and garnix falls back. 48 GiB gives headroom for parallel garnix +
+  # local builds.
   nix-rosetta-builder = {
     cores = 12;
-    memory = "24GiB";
-    onDemand = true;
+    memory = "48GiB";
+    onDemand = false;
+
+    # Let the tailscale auth below be driven with `ssh rosetta-builder` from the
+    # Mac (the guest has no secret store, so `tailscale up` is interactive once).
+    permitNonRootSshAccess = true;
+
+    # Turn the builder VM into a garnix aarch64 build target ON THE TAILNET, so
+    # garnix's SSH foothold lands in this disposable VM, never on the work Mac.
+    # The guest runs PLAIN tailscale (no --ssh), so its :22 stays a normal sshd
+    # that honours authorized_keys — the nix-ssh forced-command boundary works on
+    # :22 directly (no second port, unlike dev.oracfurt). garnix realises here in
+    # the sandbox and the tsnixcache watch daemon pushes the outputs.
+    # `inputs` is the Mac's flake inputs (captured here, embedded into the guest
+    # module) since the guest nixosSystem only has bare nixpkgs otherwise.
+    potentiallyInsecureExtraNixosModule = {
+      imports = [
+        # nix-ssh system user + forced-command `nix-daemon --stdio` + trusted-users.
+        # Same trusted builder key garnix already uses for gigabuilder/dev.oracfurt.
+        ../../common/garnix-build-target.nix
+        inputs.tsnixcache.nixosModules.tsnixcache-client
+      ];
+
+      services.tailscale.enable = true; # NO --ssh; auth interactively (see steps)
+
+      services.tsnixcache-client = {
+        enable = true;
+        package = inputs.tsnixcache.packages.aarch64-linux.default;
+        publicKey = (import ../../metadata/tsnixcache.nix).publicKey;
+        substituters = [ ];
+        watch.enable = true;
+      };
+
+      # The guest has no secret store, so `tailscale up` is run interactively
+      # once (repeated only when the VM is recreated). Give `builder` sudo for it.
+      # mkForce: the rosetta base image pins sudo off (debugInsecurely=false).
+      security.sudo.enable = lib.mkForce true;
+      security.sudo.wheelNeedsPassword = lib.mkForce false;
+      users.users.builder.extraGroups = [ "wheel" ];
+    };
   };
 
   # Configure SSH agent mux for work machine


### PR DESCRIPTION
garnix's fleet had one aarch64 builder (`dev.oracfurt` — slow, `maxJobs 1`). kratail2's rosetta-builder VM is a fast native aarch64 box already used for local + `rnb` builds; put it to work for CI too.

The VM, not the Mac host, is the tailnet build target, so garnix's SSH foothold stays in the disposable guest. It's injected into the rosetta guest via `potentiallyInsecureExtraNixosModule`: `garnix-build-target` (nix-ssh forced command), `tsnixcache-client` (pushes its own aarch64 outputs), and plain tailscale (no `--ssh`, so the build key works on `:22`). `onDemand` off + 48GiB so it's reliably present.

No scheduler needed: at `speedFactor 5` (> oracfurt's 2) stock nix `build-remote` prefers it when online and falls back to oracfurt when the Mac is off (~5s, `ConnectTimeout` pin). Only both-down fails a check — same as today's single-builder outage.

The kradalby.no ACL (`tag:garnix` -> `tag:garnix-builder`) lives in `git/infrastructure` and is already applied.

Draft: provisioning is pending. After the VM first joins the tailnet, three placeholders need filling — the guest host key (`knownHosts.rosetta-kratail2`), the VM's tailnet IP, and its `device_id`.

> Generated with the help of an AI assistant