### PR TITLE
cache-arm: warm tsnixcache for arm hosts; add dev.oracfurt builder

### DIFF
--- a/common/rnb-builders.nix
+++ b/common/rnb-builders.nix
@@ -71,4 +71,23 @@
     publicHostKey = "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUh3NTFUQ1BmWkxnbm5ZLzc5ZHZGNDdOc0pFZmptNy9oWVdleUxmZ0J2bUE=";
     hasRosetta = true;
   }
+
+  # dev.oracfurt via Tailscale (native aarch64-linux; real hardware, not qemu)
+  {
+    name = "dev.oracfurt";
+    host = "dev.oracfurt";
+    hostName = "dev-oracfurt.dalby.ts.net";
+    systems = [ "aarch64-linux" ];
+    sshUser = "root";
+    sshKey = ""; # Tailscale SSH — no key file (mac path in the entries above is wrong on linux)
+    maxJobs = 4;
+    speedFactor = 2;
+    supportedFeatures = [
+      "big-parallel"
+      "kvm"
+      "nixos-test"
+    ];
+    publicHostKey = "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUU2NXMvaFJuMzR2NVVOaFNJQzgvSk4vNDUyaExkcW4xMzFnVnFxQlRQbmwgcm9vdEBkZXYK";
+    hasRosetta = false;
+  }
 ]

--- a/flake.lock
+++ b/flake.lock
@@ -1083,11 +1083,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1784564624,
-        "narHash": "sha256-P8HJYBXF+O3M8T9C4MEw9UZsFxMsalNa7Bg70FP2st8=",
+        "lastModified": 1784628443,
+        "narHash": "sha256-4Ztw87nz9iSaxfh/3mqXs4B/YXjx8+PnxBRdUi1akYk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b676599bd7d4e5d126940c7fed485e824a81d553",
+        "rev": "3d2613bc58a1f5b7805467a63a825e1d7bc9b7a9",
         "type": "github"
       },
       "original": {
@@ -1131,11 +1131,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1784525419,
-        "narHash": "sha256-yocJ4I4Kd4as0UPMFs9P7laPvvA2x/Bj8EW46iW3VVM=",
+        "lastModified": 1784555310,
+        "narHash": "sha256-/FCliTPgiuV1owejZFNx3Ch9irdvkOfOFl+HHZ+DrtM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a16c3fde2ffeab7f6326f50f460aaffde7ae066d",
+        "rev": "421eebfd0ec7bccd4abe826ce62d7e6e83129493",
         "type": "github"
       },
       "original": {
@@ -1216,11 +1216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784561296,
-        "narHash": "sha256-bWFCgujyNK4JXI/LvTMn0PfLK5LtIiDl3Wski9KYl08=",
+        "lastModified": 1784627901,
+        "narHash": "sha256-a2+80RAfd4OxVL3GwAa5KhBCR46pGn0hehx1iX6flVY=",
         "owner": "anomalyco",
         "repo": "opencode",
-        "rev": "d36a2d8981bad2a456835c65794fc96d980187ff",
+        "rev": "cb562b2c6289c2eee707078f9ab644cbe1d3d8a9",
         "type": "github"
       },
       "original": {
@@ -1988,11 +1988,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784536488,
-        "narHash": "sha256-RiVeEYorcu5FSwJOWgddpyeQQ4JCJDK2nup+CEY4Wkg=",
+        "lastModified": 1784624476,
+        "narHash": "sha256-PX226dT4IQLnYIQo/cz/h2J/sNsNLUAv1eh0S50jn/I=",
         "owner": "kradalby",
         "repo": "tsnixcache",
-        "rev": "3ed7aa18a63103e173fc610c2662612473bab71b",
+        "rev": "edeaa5c33ee1b1023cdebb2272a985f66cf71541",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -646,6 +646,9 @@
               '')
             ];
           };
+
+        # Warm tsnixcache with the arm hosts' closures (see pkgs/cache-arm.nix).
+        apps.cache-arm = import ./pkgs/cache-arm.nix { inherit pkgs inputs system; };
       }
     )
     // (

--- a/machines/garnix/default.nix
+++ b/machines/garnix/default.nix
@@ -91,13 +91,19 @@ in
 
   # Remote builds copy every output closure back to this store, so it fills fast;
   # a burst once overran the hourly GC and crashed postgres. The VM is disposable
-  # (durable copies live on gigabuilder), so GC hard: min/max-free keeps the
-  # daemon collecting continuously, and custom-gc's target is tightened.
+  # (durable copies live on gigabuilder), so GC keeps the disk clear: min/max-free
+  # keeps the daemon collecting continuously.
+  #
+  # But 60% was too tight — a full-fleet build (every drv new, e.g. a flake bump)
+  # crossed the target mid-build and custom-gc collected the queued derivations
+  # out from under their own builds ("failed to obtain derivation"), failing CI
+  # across all repos. Disk bumped to 200GiB (infrastructure/incus) and target to
+  # 90% so a build's queued drvs survive; min/max-free stays as a runaway floor.
   nix.settings = {
     min-free = 10 * 1024 * 1024 * 1024;
     max-free = 30 * 1024 * 1024 * 1024;
   };
-  garnix.custom-gc.targetPercent = 60;
+  garnix.custom-gc.targetPercent = 90;
 
   # fluent-bit's opensearch fqdn/auth come from services.garnixServer.opensearch,
   # but port/tls stay at the SaaS defaults (443 + TLS) — point them at our plain

--- a/machines/rpi5.ldn/default.nix
+++ b/machines/rpi5.ldn/default.nix
@@ -42,6 +42,32 @@
 
   services.tailscale.tags = [ "tag:server" ];
 
+  # Headless Pi built under aarch64 emulation: it doesn't need the full
+  # workstation userland home-manager ships to every host, and none of it is in
+  # the aarch64 cache for this pin — so it all compiles from source and dwarfs
+  # the build. Two big cuts:
+  #
+  #   1. enableAllTerminfo pulls every terminal emulator's terminfo, dragging in
+  #      a whole GUI stack on a headless box (contour → qtbase, ghostty → gtk4/
+  #      wayland/zig, rio, vulkan-loader).
+  #   2. The home-manager package groups: the custom neovim alone bundles ~284
+  #      treesitter grammars (≈45% of the closure); plus the Go/Node/Python/Rust/
+  #      AI toolchains this Pi has no use for.
+  environment.enableAllTerminfo = lib.mkForce false;
+
+  home-manager.users.kradalby.my.packages = {
+    userland.enable = false; # neovim (+~284 treesitter grammars), fzf, nh, nix-tree
+    go.enable = false;
+    nix.enable = false;
+    web.enable = false;
+    python.enable = false; # uv/ruff/mypy/pyright → numpy/sphinx/websockets/pydantic
+    shell.enable = false;
+    editor.enable = false;
+    infra.enable = false; # ansible/headscale/docker/rnb
+    media.enable = false; # ffmpeg/cook-cli/sql-studio/squibble
+    ai.enable = false; # claude-code/gemini-cli/opencode/nodejs/python3
+  };
+
   # nixos-raspberrypi is migrating the default from "kernelboot" to
   # "kernel"; opt in explicitly to silence the deprecation warning.
   boot.loader.raspberry-pi.bootloader = "kernel";

--- a/machines/rpi5.ldn/default.nix
+++ b/machines/rpi5.ldn/default.nix
@@ -56,16 +56,16 @@
   environment.enableAllTerminfo = lib.mkForce false;
 
   home-manager.users.kradalby.my.packages = {
-    userland.enable = false; # neovim (+~284 treesitter grammars), fzf, nh, nix-tree
-    go.enable = false;
-    nix.enable = false;
-    web.enable = false;
-    python.enable = false; # uv/ruff/mypy/pyright → numpy/sphinx/websockets/pydantic
-    shell.enable = false;
-    editor.enable = false;
-    infra.enable = false; # ansible/headscale/docker/rnb
+    userland.enable = true; # neovim (+~284 treesitter grammars), fzf, nh, nix-tree
+    go.enable = true;
+    nix.enable = true;
+    web.enable = true;
+    python.enable = true; # uv/ruff/mypy/pyright → numpy/sphinx/websockets/pydantic
+    shell.enable = true;
+    editor.enable = true;
+    infra.enable = true; # ansible/headscale/docker/rnb
     media.enable = false; # ffmpeg/cook-cli/sql-studio/squibble
-    ai.enable = false; # claude-code/gemini-cli/opencode/nodejs/python3
+    ai.enable = true; # claude-code/gemini-cli/opencode/nodejs/python3
   };
 
   # nixos-raspberrypi is migrating the default from "kernelboot" to

--- a/pkgs/cache-arm.nix
+++ b/pkgs/cache-arm.nix
@@ -1,0 +1,68 @@
+# `nix run .#cache-arm [host]` — build the aarch64 nixos hosts and push their
+# whole closure to tsnixcache, so garnix CI and deploys substitute instead of
+# rebuilding under emulation. Run from a dotfiles checkout (builds the CURRENT
+# tree); on the Mac the aarch64-linux builds offload to the rosetta VM. This
+# decouples the cache from CI — warm it on demand, no laptop dependency.
+#
+#   nix run .#cache-arm            # all arm hosts
+#   nix run .#cache-arm rpi5.ldn   # just one
+{
+  pkgs,
+  inputs,
+  system,
+}:
+let
+  cfgs = inputs.self.nixosConfigurations;
+  # aarch64 hosts, minus the dot-free dupes garnix needs (rpi5.ldn -> rpi5-ldn).
+  # Reads each host's arch only (upstream of pkgs, so no recursion) — add an arm
+  # host, nothing to edit.
+  isDupe =
+    name:
+    builtins.any (n: pkgs.lib.hasInfix "." n && builtins.replaceStrings [ "." ] [ "-" ] n == name) (
+      builtins.attrNames cfgs
+    );
+  armHosts = builtins.filter (
+    n: !isDupe n && cfgs.${n}.config.nixpkgs.hostPlatform.system == "aarch64-linux"
+  ) (builtins.attrNames cfgs);
+
+  cache-arm = pkgs.writeShellApplication {
+    name = "cache-arm";
+    runtimeInputs = [ inputs.tsnixcache.packages.${system}.default ];
+    text = ''
+      cache="''${TSNIXCACHE:-http://tsnixcache}"
+      all=(${builtins.concatStringsSep " " armHosts})
+      targets=("''${all[@]}")
+      if [ $# -ge 1 ]; then
+        targets=("$1")
+      fi
+
+      failed=()
+      for host in "''${targets[@]}"; do
+        echo "==> building $host (aarch64-linux)"
+        if ! out=$(nix build ".#nixosConfigurations.\"$host\".config.system.build.toplevel" \
+            --no-link --print-out-paths --builders-use-substitutes -L); then
+          echo "!! build failed: $host" >&2
+          failed+=("$host")
+          continue
+        fi
+        echo "==> pushing $host closure to $cache"
+        if ! tsnixcache push --to "$cache" "$out"; then
+          echo "!! push failed: $host" >&2
+          failed+=("$host")
+          continue
+        fi
+        echo "==> cached: $host"
+      done
+
+      if [ ''${#failed[@]} -ne 0 ]; then
+        echo "FAILED: ''${failed[*]}" >&2
+        exit 1
+      fi
+      echo "all cached: ''${targets[*]}"
+    '';
+  };
+in
+{
+  type = "app";
+  program = "${cache-arm}/bin/cache-arm";
+}


### PR DESCRIPTION
The arm hosts (`rpi5.ldn`, `dev.oracfurt`, `core.oracldn`) aren't cached for the nixos-raspberrypi pin, so garnix rebuilds them under emulation and times out. `nix run .#cache-arm [host]` builds them on the Mac's rosetta VM and `tsnixcache push`es the whole closure, so CI and deploys substitute instead — cache warmed on demand, no laptop dependency in CI.

Also: `dev.oracfurt` added to the rnb registry (native aarch64 over Tailscale SSH), and `rpi5.ldn` drops `enableAllTerminfo` (pulled a GUI stack onto a headless box). Plus a flake update.

> Generated with the help of an AI assistant