### PR TITLE
machines/kratail2: document guest tailscale up, keep MagicDNS

### DIFF
--- a/machines/kratail2/default.nix
+++ b/machines/kratail2/default.nix
@@ -83,7 +83,15 @@ in
         inputs.tsnixcache.nixosModules.tsnixcache-client
       ];
 
-      services.tailscale.enable = true; # NO --ssh; auth interactively (see steps)
+      # Plain node (NO --ssh, so :22 stays a normal sshd for the nix-ssh key).
+      # No secret store in the guest, so auth interactively once per VM recreation:
+      #   ssh rosetta-builder
+      #   sudo tailscale up --hostname=rosetta-kratail2 --advertise-tags=tag:garnix-builder
+      # Do NOT pass --accept-dns=false: the tsnixcache-client below pushes to the
+      # MagicDNS name http://tsnixcache, so the guest must keep MagicDNS or `nix
+      # copy` can't resolve the cache and pushes fail silently. Sanity-check with
+      # `getent hosts tsnixcache`.
+      services.tailscale.enable = true;
 
       services.tsnixcache-client = {
         enable = true;


### PR DESCRIPTION
Follow-up to the kratail2 rosetta builder (#53/#54). The guest's `tsnixcache-client` watch daemon pushes to the MagicDNS name `http://tsnixcache`, so the guest must keep MagicDNS. The provisioning step I'd documented used `--accept-dns=false`, which stops the guest resolving `tsnixcache` and makes `nix copy` pushes fail silently — the aarch64 outputs never reach the cache.

No functional change; records the correct one-time `tailscale up` (no `--accept-dns=false`) as a comment next to the config so the next VM recreation gets it right.

> Generated with the help of an AI assistant