### PR TITLE
machines/core.oracldn: provision sloth SLO dashboard

### DIFF
--- a/machines/core.oracldn/grafana.nix
+++ b/machines/core.oracldn/grafana.nix
@@ -41,6 +41,18 @@ let
       }
     } $out/incus.json
 
+    # Sloth SLO dashboard. Panels reference the datasource by the unresolved
+    # ''${DS_PROMETHEUS} input uid, which Grafana falls back to our default
+    # (Prometheus) datasource for — same as incus above, so no sed needed.
+    cp ${
+      fetchDashboard {
+        id = 14348;
+        rev = versions.grafanaDashboards.sloth.rev;
+        hash = versions.grafanaDashboards.sloth.hash;
+        name = "sloth.json";
+      }
+    } $out/sloth.json
+
     # tsnixcache dashboard, generated from Go (Foundation SDK) in the tsnixcache
     # repo and shipped as a flake package, so it tracks the metrics it charts.
     cp ${

--- a/metadata/versions.nix
+++ b/metadata/versions.nix
@@ -17,6 +17,11 @@
       rev = "2";
       hash = "sha256-3+f11v3qfTmM6poCwjUAlQmyZNs9X0TwcCdxFTreyuQ=";
     };
+    # https://grafana.com/grafana/dashboards/14348-sloth-slo-detail/
+    sloth = {
+      rev = "5";
+      hash = "sha256-kmJoFy8ZmSKN0WsoBUQEepOpfNfmTjGciKFzhcFgeCU=";
+    };
   };
 
   # https://github.com/umami-software/umami/pkgs/container/umami


### PR DESCRIPTION
Sloth generates the SLO recording/alert rules but no dashboards, so the burn-rate and error-budget metrics had nothing rendering them. Pull in the upstream Sloth dashboard (grafana.com `14348`, *SLO / Detail*) so the SLOs are actually viewable.

Reuses the existing `fetchDashboard` idiom with `rev`/`hash` pinned in `metadata/versions.nix`. Plain copy like `incus` — its `${DS_PROMETHEUS}` uid refs fall back to the default `Prometheus` datasource, so no sed rewrite needed. Template vars bind to the standard `sloth_service`/`sloth_slo` labels, no remapping.

> Generated with the help of an AI assistant