### PR TITLE
restic: fix repository checks; dev.oracfurt: serve cooklang VIP on tcp:443

### DIFF
--- a/machines/dev.oracfurt/syncthing.nix
+++ b/machines/dev.oracfurt/syncthing.nix
@@ -82,6 +82,11 @@ in
   services.tailscale.services.syncthing-cooklang = {
     endpoints = {
       "tcp:80" = "http://127.0.0.1:8385";
+      # tcp:443 has no TLS termination — Tailscale VIP bug (tailscale/tailscale#19724, #18381); consumers use http. TODO(kradalby): revert when fixed.
+      # Must be served: services.tf registers this VIP with tcp:443, and a VIP
+      # that leaves a declared port unserved is never distributed to the
+      # tailnet (`tailscale whois` on its address: peer not found).
+      "tcp:443" = "http://127.0.0.1:8385";
     };
   };
 }

--- a/modules/restic-jobs-linux.nix
+++ b/modules/restic-jobs-linux.nix
@@ -62,6 +62,11 @@ in
             # password file, and extra options (incl. rclone remotes).
             serviceConfig = {
               Type = "oneshot";
+              # systemd only exports $HOME when User= is set. rclone needs it
+              # to find rclone.conf; without it it shells out to `getent`,
+              # which is not on this unit's PATH, and the check dies with
+              # "didn't find section in config file". Mirror the backup unit.
+              User = config.services.restic.backups.${jobName}.user;
               ExecStart = "/run/current-system/sw/bin/restic-${jobName} check ${escapeShellArgs jobCfg.check.args}";
             };
           }

--- a/modules/restic-jobs-linux.nix
+++ b/modules/restic-jobs-linux.nix
@@ -67,7 +67,15 @@ in
               # which is not on this unit's PATH, and the check dies with
               # "didn't find section in config file". Mirror the backup unit.
               User = config.services.restic.backups.${jobName}.user;
-              ExecStart = "/run/current-system/sw/bin/restic-${jobName} check ${escapeShellArgs jobCfg.check.args}";
+              # Type=oneshot defaults to no start timeout. A wedged rclone or
+              # REST connection would hang in `activating` forever — which is
+              # not `failed`, so ServiceFailed never fires. Bound it clear of
+              # the lock wait plus a --read-data-subset run.
+              TimeoutStartSec = "6h";
+              # Backups run hourly and this timer has a 6h random delay, so
+              # overlap is routine; restic defaults to no lock retry and exits
+              # 11 the moment it finds the repository locked.
+              ExecStart = "/run/current-system/sw/bin/restic-${jobName} check --retry-lock=1h ${escapeShellArgs jobCfg.check.args}";
             };
           }
         )

--- a/modules/restic-jobs.nix
+++ b/modules/restic-jobs.nix
@@ -206,9 +206,13 @@ let
           paths
           pruneOpts
           initialize
-          extraBackupArgs
           extraOptions
           ;
+        # `restic check` takes an exclusive lock, so once it stops failing
+        # fast it will hold one for real. Backups have to wait it out too, or
+        # the fix just moves the failure to the backup unit. 45m keeps a
+        # waiting backup from running past the next hourly tick.
+        extraBackupArgs = [ "--retry-lock=45m" ] ++ jobCfg.extraBackupArgs;
         passwordFile = config.age.secrets.${jobCfg.secret}.path;
       }
       // optionalAttrs (jobCfg.dynamicFilesFrom != null) {


### PR DESCRIPTION
Three `critical ServiceFailed` pages (core-tjoda, storage-ldn, dev-ldn) and one
`ExporterDown`, all from config rather than from anything actually broken.
Backups were never affected — only the check units.

`restic-check-*` was built with just `Type` and `ExecStart`, which left two
independent defects. Without `User=`, systemd never exports `$HOME`, so rclone
fell back to `getent` (not on the unit PATH) and could not read `rclone.conf` —
that is storage-ldn. And with hourly backups against a check timer carrying
`RandomizedDelaySec=6h`, overlap is routine, while restic defaults to no lock
retry and exits 11 on contention — that is core-tjoda, and almost certainly
dev-ldn too, though it stays unverified while that host is SSH-locked-out.

Retrying the lock alone would have traded check failures for backup failures,
since `restic check` holds an *exclusive* lock and currently only avoids doing
so by dying immediately. So backups retry too, at 45m — under the hourly tick.

`Type=oneshot` also disables the start timeout, and a unit wedged in
`activating` is not `failed`, so `ServiceFailed` would never fire on a hung
connection. That hole predates this change but gets more reachable once checks
start waiting, so the check is bounded at 6h.

Separately, `svc:syncthing-cooklang` was registered in `services.tf` with
`tcp:443` but only served `tcp:80`. A VIP that leaves a declared port unserved
is never distributed — `tailscale whois` on its address returned `peer not
found` from every host on the tailnet. It is the only VIP in the fleet with
that mismatch, and the only broken one.

Verify without waiting for timers: `systemctl start restic-check-jotta` on
storage-ldn and on core-tjoda mid-backup, then `tailscale whois 100.76.10.106`
from core-oracldn.

> Generated with the help of an AI assistant