### PR TITLE
monitoring: fix pushgateway host collision and NVMe temp threshold

### DIFF
--- a/machines/core.oracldn/monitoring.nix
+++ b/machines/core.oracldn/monitoring.nix
@@ -1151,12 +1151,21 @@ in
               }
               {
                 alert = "SMARTDiskTemperature";
-                expr = ''smartctl_device_temperature{temperature_type="current"} > 55'';
+                # NVMe runs hot by design and reports a composite temperature;
+                # 55C is a spinning-rust/SATA number and false-positives on it.
+                # gigabuilder's Kingston SNV3S500G warns at 75C and throttles at
+                # 80C (its own Warning/Critical Comp. Temp. Thresholds), so 70C
+                # still leaves room to act before the drive complains.
+                expr = ''
+                  smartctl_device_temperature{temperature_type="current",device!~"nvme.*"} > 55
+                  or
+                  smartctl_device_temperature{temperature_type="current",device=~"nvme.*"} > 70
+                '';
                 for = "15m";
                 labels.severity = "warning";
                 annotations = {
                   summary = "Disk {{ $labels.device }} on {{ $labels.instance }} is {{ $value }}C";
-                  description = "Disk temperature on {{ $labels.device }} ({{ $labels.model_name }}) has been above 55C for more than 15 minutes.";
+                  description = "Disk temperature on {{ $labels.device }} ({{ $labels.model_name }}) has been high for more than 15 minutes (limit 55C, or 70C for NVMe).";
                 };
               }
             ];

--- a/modules/restic-jobs-linux.nix
+++ b/modules/restic-jobs-linux.nix
@@ -8,6 +8,16 @@ with lib;
 let
   cfg = config.services.restic.jobs;
 
+  # Fleet identity is <host>-<site> (core-tjoda, dev-ldn) — the same name the
+  # tailnet and every scrape target uses. NEVER the bare hostName: `core`,
+  # `dev` and `storage` are each shared by two machines, so a bare name merges
+  # two hosts into one pushgateway series and a failing host is hidden behind
+  # its healthy twin. Hosts without a site (garnix, gigabuilder) keep their
+  # plain name, since removeSuffix leaves nothing to dash.
+  fleetInstance = builtins.replaceStrings [ "." ] [ "-" ] (
+    removeSuffix ".fap.no" config.networking.fqdnOrHostName
+  );
+
   # State directories of DynamicUser units live under /var/lib/private/<x>;
   # /var/lib/<x> is only a symlink and restic snapshots it as ~20 bytes.
   # A backup path that is itself a symlink is essentially always this
@@ -34,7 +44,7 @@ let
     pkgs.writeShellScript "restic-push-success-${jobName}" ''
       [ "$SERVICE_RESULT" = "success" ] || exit 0
       ${pkgs.curl}/bin/curl -s --max-time 30 --data-binary @- \
-        "http://pushgateway/metrics/job/restic/instance/$(${pkgs.coreutils}/bin/uname -n)/repo/${jobName}" <<EOF || true
+        "http://pushgateway/metrics/job/restic/instance/${fleetInstance}/repo/${jobName}" <<EOF || true
       # TYPE restic_backup_last_success_timestamp_seconds gauge
       restic_backup_last_success_timestamp_seconds $(${pkgs.coreutils}/bin/date +%s)
       EOF


### PR DESCRIPTION
Two independent monitoring-correctness fixes, neither changing what is
monitored — only whether the signal is trustworthy.

**Pushgateway host collision.** `pushSuccess` keyed the backup-success series on
`uname -n`, which is the bare hostname. Three pairs of machines share one:
`core` (core-oracldn + core-tjoda), `dev` (dev-ldn + dev-oracfurt) and `storage`
(storage-ldn + storage-bassan). Both halves of each pair wrote to the same
`instance`/`repo` series, so the healthy twin's push overwrote the failing one's
and `ResticBackupNotSucceeding` could never fire. This was not theoretical:
dev-ldn's hourly backups to both `ldn` and `tjoda` have been failing since
2026-08-05 while the metric reported success, and storage-bassan's staleness has
been masked by storage-ldn since it went offline to be moved. Fleet identity is
`<host>-<site>`, never the bare hostname.

Derived from the fqdn rather than `hostName + domain` because garnix and
gigabuilder have `domain = fap.no` with no site component, which the naive form
would render `garnix-fap`. `fqdnOrHostName` so a domain-less host cannot make
the module throw.

**NVMe temperature threshold.** 55C is a SATA/spinning-rust number.
gigabuilder's Kingston SNV3S500G reports its own Warning/Critical Comp. Temp.
Thresholds as 75C/80C, so it false-positived at 61C. NVMe now alerts at 70C,
leaving headroom before the drive itself complains; everything else keeps 55C.
Verified live: the new expression returns empty, and probing each branch
independently confirms neither is dead.

**Deploying this requires a follow-up.** Pushgateway retains a group until it is
explicitly deleted, so after the cutover the ten old `instance=core|dev|home|
storage` series remain with frozen timestamps and would fire
`ResticBackupNotSucceeding` permanently. They must be `DELETE`d once the last
host is switched over.

> Generated with the help of an AI assistant