### PR TITLE
restic: keep temp packs off tmpfs; monitoring: guard unfired timers

### DIFF
--- a/machines/core.oracldn/monitoring.nix
+++ b/machines/core.oracldn/monitoring.nix
@@ -1543,7 +1543,15 @@ in
               }
               {
                 alert = "ResticBackupStale";
-                expr = ''time() - systemd_timer_last_trigger_seconds{name=~"restic-backups-.*\\.timer",name!~"restic-backups-jotta\\.timer"} > 2 * 3600'';
+                # The `> 0` guard: systemd reports LastTriggerUSec=0 for a
+                # timer that has not fired since boot, so `time() - 0` looks
+                # infinitely stale and every reboot false-paged until the next
+                # tick. A timer that never fires is still covered by
+                # ResticBackupNotSucceeding and ResticRepoNoNewSnapshots.
+                expr = ''
+                  time() - systemd_timer_last_trigger_seconds{name=~"restic-backups-.*\\.timer",name!~"restic-backups-jotta\\.timer"} > 2 * 3600
+                  and systemd_timer_last_trigger_seconds{name=~"restic-backups-.*\\.timer",name!~"restic-backups-jotta\\.timer"} > 0
+                '';
                 for = "30m";
                 labels.severity = "critical";
                 annotations = {
@@ -1575,7 +1583,11 @@ in
               }
               {
                 alert = "ResticBackupStaleJotta";
-                expr = ''time() - systemd_timer_last_trigger_seconds{name=~"restic-backups-jotta\\.timer"} > 4 * 3600'';
+                # See ResticBackupStale for why the `> 0` guard is needed.
+                expr = ''
+                  time() - systemd_timer_last_trigger_seconds{name=~"restic-backups-jotta\\.timer"} > 4 * 3600
+                  and systemd_timer_last_trigger_seconds{name=~"restic-backups-jotta\\.timer"} > 0
+                '';
                 for = "30m";
                 labels.severity = "critical";
                 annotations = {
@@ -1662,7 +1674,13 @@ in
               }
               {
                 alert = "PostgresqlBackupStale";
-                expr = ''time() - systemd_timer_last_trigger_seconds{name=~"postgresqlBackup-.*\\.timer"} > 26 * 3600'';
+                # See ResticBackupStale for the `> 0` guard. This one bit
+                # hardest: pg_dump is nightly, so a reboot false-paged
+                # critical for hours rather than until the next hourly tick.
+                expr = ''
+                  time() - systemd_timer_last_trigger_seconds{name=~"postgresqlBackup-.*\\.timer"} > 26 * 3600
+                  and systemd_timer_last_trigger_seconds{name=~"postgresqlBackup-.*\\.timer"} > 0
+                '';
                 for = "30m";
                 labels.severity = "critical";
                 annotations = {

--- a/modules/restic-jobs-linux.nix
+++ b/modules/restic-jobs-linux.nix
@@ -60,6 +60,13 @@ in
           mkIf jobCfg.enable {
             serviceConfig.ExecStartPre = [ (symlinkGuard jobName jobCfg) ];
             serviceConfig.ExecStopPost = [ (pushSuccess jobName) ];
+            # restic streams pack files through $TMPDIR. The default /tmp is a
+            # 4G tmpfs here, so unrelated scratch files can starve a backup:
+            # every job on dev-ldn died on "no space left on device" writing
+            # /tmp/restic-temp-pack-*. CacheDirectory= already gives us a
+            # disk-backed per-job dir; point TMPDIR at it so backups only
+            # compete with themselves.
+            environment.TMPDIR = "/var/cache/restic-backups-${jobName}";
           }
         )
       ) cfg)
@@ -68,10 +75,16 @@ in
         nameValuePair "restic-check-${jobName}" (
           mkIf (jobCfg.enable && jobCfg.check.enable) {
             description = "restic repository check for ${jobName}";
+            # Same tmpfs starvation applies to `check`, which unpacks into
+            # $TMPDIR while verifying — keep it on disk with the backup job.
+            environment.TMPDIR = "/var/cache/restic-backups-${jobName}";
             # The restic module's generated wrapper carries the repository,
             # password file, and extra options (incl. rclone remotes).
             serviceConfig = {
               Type = "oneshot";
+              # Same dir the backup unit gets; declared here too so the check
+              # cannot run before it exists (TMPDIR above points into it).
+              CacheDirectory = "restic-backups-${jobName}";
               # systemd only exports $HOME when User= is set. rclone needs it
               # to find rclone.conf; without it it shells out to `getent`,
               # which is not on this unit's PATH, and the check dies with


### PR DESCRIPTION
Both fixes come from a real outage: every restic job on dev-ldn failed for a
day, and the reboots that deployed the previous PR then false-paged critical.

**Temp packs off tmpfs.** restic streams pack files through `$TMPDIR`, which
defaults to `/tmp` — a 4G tmpfs. Unrelated scratch files filled it and all
three backups died on `no space left on device` writing
`/tmp/restic-temp-pack-*`. Nothing was wrong with the repos or the network;
there was simply no scratch space. `CacheDirectory=` already provides a
disk-backed per-job directory, so `TMPDIR` now points there and a backup only
competes with itself. Declared on the check unit too, which unpacks into
`$TMPDIR` while verifying, along with the matching `CacheDirectory=` so the
check can never run before the directory exists.

**Unfired-timer guard.** systemd reports `LastTriggerUSec=0` until a timer's
first run after boot, so `time() - 0` looks infinitely stale. Rebooting
core.oracldn and home.ldn put `ResticBackupStale` into pending on both and
fired `PostgresqlBackupStale` critical. The restic timers are hourly and
self-healed within the hour; pg_dump is nightly, so that one would have paged
for four hours. All three affected rules now require `> 0`.

The trade-off: a timer that never fires after boot becomes invisible to these
rules. That case is still covered by `ResticBackupNotSucceeding` (pushgateway,
3h) and `ResticRepoNoNewSnapshots` (repo-side), so the narrowing is
deliberate rather than free.

Verified against live data that the guard does not suppress genuine staleness
— 44 real matches with and without it. The `= 0` condition itself had already
cleared by the time the fix was written, so that half is reasoned from the
observed failure rather than re-demonstrated.

> Generated with the help of an AI assistant