### PR TITLE
core.tjoda: install munin from nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -742,7 +742,7 @@
     "headscale_2": {
       "inputs": {
         "flake-utils": "flake-utils_7",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1782917259,
@@ -762,7 +762,7 @@
     "headscale_3": {
       "inputs": {
         "flake-utils": "flake-utils_10",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1782917259,
@@ -956,6 +956,24 @@
       "original": {
         "owner": "containers",
         "repo": "libkrun",
+        "type": "github"
+      }
+    },
+    "munin": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1787472469,
+        "narHash": "sha256-LxviWu0g4cLUFdYUWDJDWJvelUw8OMyNnxhM/KUkBAA=",
+        "owner": "kradalby",
+        "repo": "munin",
+        "rev": "33f0714b1b84034dddc22c15ba3b95ca971677fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kradalby",
+        "repo": "munin",
         "type": "github"
       }
     },
@@ -1270,6 +1288,20 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1785301185,
+        "narHash": "sha256-PlAXr9kpfXhMFU0OQ7qtE8FhLQo21WXFVGqIC85UFyc=",
+        "rev": "9bc02893134c733dd85de46ee4fb2fac696b5529",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1043539.9bc02893134c/nixexprs.tar.xz"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixpkgs-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1781153106,
         "narHash": "sha256-yzsroLCcuRG4KdGMxWt0eXKOrRSgQT8/xjYngeq9ujU=",
         "owner": "NixOS",
@@ -1284,7 +1316,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1781153106,
         "narHash": "sha256-yzsroLCcuRG4KdGMxWt0eXKOrRSgQT8/xjYngeq9ujU=",
@@ -1360,6 +1392,7 @@
         "hugin": "hugin",
         "hvor": "hvor",
         "krapage": "krapage",
+        "munin": "munin",
         "nefit-homekit": "nefit-homekit",
         "neovim-kradalby": "neovim-kradalby",
         "nix-index-database": "nix-index-database",

--- a/flake.nix
+++ b/flake.nix
@@ -135,7 +135,8 @@
       inputs."flake-utils".follows = "flake-utils";
     };
 
-    # munin.url = "github:kradalby/munin";
+    munin.url = "github:kradalby/munin";
+
     neovim-kradalby = {
       url = "github:kradalby/neovim";
       inputs."flake-utils".follows = "flake-utils";
@@ -235,6 +236,8 @@
         tasmota-exporter.overlays.default
         homewizard-p1-exporter.overlays.default
         ghdl.overlays.default
+        # Adds `munin-gallery` (binary `munin`), x86_64-linux only.
+        munin.overlays.default
         (import ./pkgs/overlays { })
         (
           final: prev:

--- a/machines/core.tjoda/hugin.nix
+++ b/machines/core.tjoda/hugin.nix
@@ -1,7 +1,7 @@
 # hugin serves the Munin-generated gallery off the 850 EVO. It is a tsnet app
 # (kraweb), so it joins the tailnet as its own node `hugin` and exposes
 # /metrics there — no VIP, same shape as hvor/krapage on core.oracldn.
-{ config, ... }:
+{ config, pkgs, ... }:
 let
   # Munin writes the gallery hugin serves, so Munin's targetFolder and hugin's
   # contentDir have to name the same directory. Derived from one value here
@@ -30,18 +30,14 @@ in
     environmentFile = config.age.secrets.hugin-env.path;
   };
 
-  # Munin is installed by hand at ~/bin/munin and run manually. Not because it
-  # resists packaging — it is a static musl binary that needs no Swift here —
-  # but because the only build it publishes today is a CI artifact: auth-gated,
-  # ephemeral URL, and deleted after 7 days, so fetchurl cannot pin it. A v*
-  # tag makes static-release.yml publish munin-linux-{amd64,arm64} and
-  # SHA256SUMS as release assets, and then this becomes an ordinary derivation.
-  # sourceFolder/targetFolder are relative to the working directory, hence the
-  # cd:
+  # Run by hand when photos are added. sourceFolder/targetFolder are relative
+  # to the working directory, hence the cd:
   #   cd /pictures && munin --config /etc/munin/munin.json --json
   # --json writes JSON and no images, which is what a URL-format change needs;
   # without it Munin may re-encode every scaled image. It rewrites all of the
   # JSON, not just index.json — the per-photo sidecars carry URLs too.
+  environment.systemPackages = [ pkgs.munin-gallery ];
+
   environment.etc."munin/munin.json".text = builtins.toJSON {
     inherit sourceFolder;
     targetFolder = baseNameOf contentDir;


### PR DESCRIPTION
`munin` now packages its static Linux build, so the gallery generator no
longer has to be a 176 MB binary dropped into `~/bin` by hand and forgotten
about. Deleted from the host.

Overlay attr is `munin-gallery` — nixpkgs' `munin` is the resource monitor,
and shadowing it on a monitoring host would swap out a daemon. Binary is
still `munin`.

No `nixpkgs` follows on the input: the overlay ignores `final`/`prev` and
builds against munin's own pin on purpose, since thumbnails are a function of
the libvips it was smoke-tested against. Costs one extra nixpkgs in the lock.

Deployed; closure diff was one entry (`munin-static-x86_64`, +70.8 MiB) and
`command -v munin` resolves to `/run/current-system/sw/bin/munin`.

> Generated with the help of an AI assistant