### PR TITLE
core.tjoda: let hugin read munin's source folder

### DIFF
--- a/machines/core.tjoda/hugin.nix
+++ b/machines/core.tjoda/hugin.nix
@@ -30,6 +30,12 @@ in
     environmentFile = config.age.secrets.hugin-env.path;
   };
 
+  # Munin symlinks originals out of contentDir into sourceFolder, so hugin has
+  # to read /pictures/album too. Samba already forces storage:storage there.
+  # Without this every page serves fine while each original download 403s —
+  # plain filesystem permissions, not the sandbox.
+  systemd.services.hugin.serviceConfig.SupplementaryGroups = [ "storage" ];
+
   # Run by hand when photos are added. sourceFolder/targetFolder are relative
   # to the working directory, hence the cd:
   #   cd /pictures && munin --config /etc/munin/munin.json --json


### PR DESCRIPTION
Friends (and I) got `403 Forbidden` downloading any original photo from hugin, while every page and thumbnail served fine.

Munin symlinks originals rather than copying them, so each
`/pictures/hugin/**/*_original.*` resolves into `/pictures/album` — a tree
`contentDir` never covered and the `hugin` user had no claim on.
`http.Dir.Open` follows the link, the kernel returns EACCES, and net/http maps
that to exactly `403`. Scaled derivatives are real files inside `contentDir`,
which is the whole asymmetry.

Not the sandbox: `ProtectSystem=strict` remounts read-only and hides nothing,
so no unit setting substitutes for the filesystem permission. `samba.nix`
already forces `storage:storage` across `/pictures` for this reason, so
joining that group is the fix.

Verify before merging — if `namei -l` on a resolved original shows a `0700`
component, group membership cannot help and it needs `chmod g+rX` too:

```
sudo -u hugin namei -l /pictures/hugin/root/<Album>/<Photo>_original.jpeg
```

> Generated with the help of an AI assistant