### PR TITLE
gigabuilder: fetch Go modules directly

### DIFF
--- a/machines/gigabuilder/builder.nix
+++ b/machines/gigabuilder/builder.nix
@@ -10,4 +10,12 @@
   # (pinned there in ~/git/infrastructure). Without this, offloaded builds starve
   # the VM's vcpus and incus resets it (~80-min crash-loop under load).
   systemd.services.nix-daemon.serviceConfig.CPUAffinity = "4-31";
+
+  # proxy.golang.org 403s the signed storage.googleapis.com redirect from this
+  # host, so every buildGoModule vendor fetch fails here while succeeding
+  # elsewhere. Fetch from the source repos instead. GOPROXY is an impure env var
+  # for those fixed-output derivations (pkgs/build-support/go/module.nix), so
+  # this changes no vendorHash — only where the bytes come from. go.sum and the
+  # checksum database still verify them.
+  systemd.services.nix-daemon.environment.GOPROXY = "direct";
 }


### PR DESCRIPTION
Every `buildGoModule` vendor fetch fails on this builder:

```
github.com/klauspost/compress@v1.19.1:
  reading https://proxy.golang.org/.../v1.19.1.zip: 403 Forbidden
```

It is not the module. From other hosts the same URL is a 302 to a signed
`storage.googleapis.com` link that returns 200 — something in this host's
egress is rejecting the signed URL, which is what a proxy rewriting the query
string looks like to GCS. Verified `GOPROXY=direct` fetches that exact module
without trouble.

`GOPROXY` is listed in `impureEnvVars` for the vendor derivation
(`pkgs/build-support/go/module.nix`), so this changes no `vendorHash` — only
where the bytes come from. `go.sum` and the checksum database still verify
them.

This unblocks kradalby/hugin#258, whose Go checks have failed on this builder
for every push. Worth treating as a workaround: the egress problem itself is
still unexplained, and `direct` fetches from the source repos, which is slower
and exposed to forge rate limits for large dependency sets.

> Generated with the help of an AI assistant