### PR TITLE
gigabuilder: source v6 from our assigned 27ee::/48

### DIFF
--- a/machines/gigabuilder/networking.nix
+++ b/machines/gigabuilder/networking.nix
@@ -35,12 +35,6 @@
           prefixLength = 24;
         }
       ];
-      ipv6.addresses = [
-        {
-          address = "2a03:94e0:ffff:194:32:107::146";
-          prefixLength = 118;
-        }
-      ];
     };
 
     defaultGateway = {
@@ -59,4 +53,14 @@
       "2606:4700:4700::1111"
     ];
   };
+
+  # 27ee:: is our assigned prefix and the primary source address; the shared
+  # ffff:: one is deprecated, so it only takes inbound.
+  systemd.network.networks."40-${config.my.wan}".addresses = [
+    { Address = "2a03:94e0:27ee::146/128"; }
+    {
+      Address = "2a03:94e0:ffff:194:32:107::146/118";
+      PreferredLifetime = "0";
+    }
+  ];
 }


### PR DESCRIPTION
Every `buildGoModule` vendor fetch offloaded to gigabuilder fails. garnix builds
x86_64 there, so this breaks CI for any Go flake.

Root cause is egress, not Go. Google has no geolocation for Gigahost's shared
`2a03:94e0:ffff::/48` mapping range — sourced from it, `youtube.com` reports
`gl=US` (Google's no-data default) and `storage.googleapis.com` answers 403
"not available in your location". `proxy.golang.org` redirects module zips to a
signed GCS URL, so the zip 403s while `/@v/list` and `/@v/*.info` keep working.
Not Go-specific: any `fetchurl` aimed at Google storage fails the same way.

Our own assigned `2a03:94e0:27ee::/48` is already routed here and geolocates
correctly. `PreferredLifetime=0` deprecates the old address so RFC 6724 rule 3
makes the kernel skip it when picking a source — that steers every process,
including Go, which honours neither `/etc/gai.conf` nor connect-level fallback
for an application-layer 403. Both addresses move into
`systemd.network.networks` because only the networkd `[Address]` section can
express a lifetime.

Verified live on gigabuilder before deploying: kernel picks
`2a03:94e0:27ee::146` as source unprompted, signed GCS URL and
`commondatastorage.googleapis.com` both 200, and `garnix.kradalby.no` still
serves 200 on the deprecated address its AAAA points at.

Supersedes #71, which set `GOPROXY=direct` — Go-only, and treats an egress
fault as a Go problem.

Unrelated but worth reporting to Gigahost: their geofeed at
`https://as56655.net/geofeed.csv` is correct and covers `2a03:94e0::/32`, but of
their 19 RIPE `inet(6)num` objects only `45.88.200.0/22` carries the `geofeed:`
attribute, so RFC 9092 per-prefix discovery cannot find it.

> Generated with the help of an AI assistant