### PR TITLE
ac: long-lived deploy sessions with a gate that owns the command name

### DIFF
--- a/.agents/skills/deploy/SKILL.md
+++ b/.agents/skills/deploy/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: deploy
+description: Deploy the NixOS/darwin fleet from master with colmena. Use for any fleet deploy, host reboot, or post-deploy verification in this repo.
+---
+
+# Deploy the fleet
+
+## Scope
+
+Deploy THIS repo to the hosts declared in `flake.nix` / `machines/`. Do not
+write features, do not open PRs, do not deploy another repo. A host not in
+`machines/` is out of scope — say so and stop. One host per deploy; never
+`colmena apply` without `--on`.
+
+## Preconditions
+
+`colmena` in this devShell is wrapped: `apply`, `apply-local` and
+`upload-keys` refuse unless the repo is on `master`, clean, in sync with
+`origin`, and has nothing unpushed. If it refuses, report the message and
+stop. Do not commit, push, checkout, stash or fetch to make it pass — that is
+the human's call. `git-ready` runs the same check on demand.
+
+Confirm CI is green for `HEAD`:
+
+    gh pr checks
+
+Fall back to the garnix API when `gh` is unclear — it reports `pending 0s`
+for a build that is actively running, which looks identical to one that was
+never dispatched:
+
+    direnv exec . sh -c 'curl -s -H "Authorization: Bearer $GARNIX_TOKEN" \
+      "$GARNIX_SERVER/api/commits/$(git rev-parse HEAD)"'
+
+A build with no `status` key is pending, not failed; a real `start_time` on
+`$GARNIX_SERVER/api/build/<id>` proves it is running. aarch64 is slow — check
+the cache is populated rather than assuming a stall.
+
+## Preview
+
+    nix flake check
+    colmena build --on <node> --keep-result     # GC roots land in ./.gcroots
+    ssh root@<node> nixos-version --json | jq -r .configurationRevision
+    git log --oneline <that rev>..HEAD
+
+That last range is what is actually landing. A host tens of commits behind is
+not a one-service deploy — it lands the whole backlog, including deliberate
+deletions made months ago.
+
+The real closure diff cannot happen here: hosts have `max-jobs = 0`, so the
+new closure is not on the target until it is pushed. That is step 2 of
+Execute, and it is the last exit point.
+
+## Execute
+
+One host at a time. Wait for Verify to pass before starting the next.
+
+Capture the baseline first — Verify depends on it:
+
+    ssh root@<node> 'systemctl list-units --state=running --no-legend | wc -l'
+    ssh root@<node> 'systemctl list-unit-files --state=enabled --type=service \
+      --no-legend | awk "{print \$1}" | grep -v @ \
+      | xargs -r -I{} sh -c "systemctl is-active --quiet {} || echo {}" | sort'
+
+1.  `colmena apply boot --on <node>` — idempotent: yes; self-severing: no.
+    Pushes the closure and arms the next boot. Touches no running unit.
+
+2.  Read the diff. After step 1 `/run/current-system` is still the old
+    generation while `/nix/var/nix/profiles/system` is the new one:
+
+        ssh root@<node> 'nix store diff-closures /run/current-system /nix/var/nix/profiles/system'
+
+    Read the **removals**, not just the additions. Escalate here — not after
+    the reboot — if it shows any of:
+    - a kernel or zfs-kernel change,
+    - a tailscale/tailscaled version change,
+    - a service disappearing that you did not expect,
+    - anything under `secrets/` moving,
+    - a closure delta far larger than the commit range explains.
+
+    Step 1 already armed the next boot, so backing out is not "do nothing".
+    Undo it explicitly before any reboot, planned or not:
+
+        ssh root@<node> 'nix-env -p /nix/var/nix/profiles/system --rollback && \
+          /nix/var/nix/profiles/system/bin/switch-to-configuration boot'
+
+3.  `ssh root@<node> systemctl reboot` — idempotent: yes; self-severing: yes.
+
+**Never `colmena apply switch`, and never `--reboot`.** colmena rides SSH over
+the tailnet. An activation that restarts tailscaled severs colmena's own
+connection, `switch-to-configuration` dies as a child of that session, and the
+host is left with units **stopped but never started** — reporting
+`is-system-running: running` with zero failed units, because a cleanly stopped
+unit is invisible to the failed count. That gutted storage.ldn for 26 hours
+and took 12 services down on core.oracldn. `apply boot` cannot sever anything
+because it never restarts a unit, and the reboot then activates the whole
+generation from PID 1, which also repairs a previously half-applied one.
+`--reboot` is a live switch _plus_ a reboot, so it keeps the severing window —
+it is not the safe option.
+
+### Order
+
+1. **x86** — `home.ldn`, `storage.ldn`, `ts1p.ldn`, `core.tjoda`,
+   `storage.bassan`, `gigabuilder`, `garnix`.
+2. **arm64** — `core.oracldn`, `dev.oracfurt`, `rpi5.ldn`. Check the cache is
+   populated first: `nix run .#cache-arm`. Without it they build under
+   emulation, which is slow enough to look hung.
+3. **dev.ldn** — after approval. Last, because it is the sole builder: every
+   other host has `max-jobs = 0` and needs it up.
+
+### Per-host
+
+- **dev.ldn** is this workstation. `ssh root@dev-ldn` is SSH-to-self and is
+  refused; that is correct, not drift. Deploy it locally:
+  `PATH=/run/wrappers/bin:$PATH colmena apply-local --sudo --node dev.ldn`
+  (the real sudo lives in `/run/wrappers/bin`).
+- **gigabuilder** hosts the Incus guests `garnix`, `ts1p.ldn`, `dev.ldn`,
+  `home.ldn`, `storage.ldn`. Deploying it restarts incus and bounces all of
+  them. Deploy it alone and let it settle.
+- **darwin** (`kratail2`, `krair`) are not colmena nodes; deploy on the
+  machine itself with `darwin-rebuild switch --flake .#<host>`.
+  `kradalby-llm` is standalone home-manager:
+  `home-manager switch --flake .#ubuntu@kradalby-llm -b backup`.
+
+If a switch did sever mid-activation, finish it detached so it survives the
+disconnect:
+
+    ssh root@<node> 'systemd-run --unit=complete-activation --collect \
+      --service-type=oneshot /run/current-system/bin/switch-to-configuration switch'
+
+## Verify
+
+Three outcomes: pass, fail, **inconclusive**. Inconclusive stops and asks — it
+is not "probably fine".
+
+Run `/kra-triage` after the host is back and read alertmanager; it covers the
+fleet-wide signals this list does not.
+
+1.  `ssh root@<node> systemctl is-system-running` — `running` = pass,
+    `degraded` = fail, no answer inside the reboot window = inconclusive.
+2.  Running-unit count against the Execute baseline. **Fewer units than before
+    = fail**, even with zero failed units.
+3.  `ssh root@<node> nixos-version --json | jq -r .configurationRevision` must
+    equal `git rev-parse HEAD`. `DIRTY` means it was built from an unclean tree.
+4.  Prometheus, by short name. PromQL on stdin — inline `query=` gets
+    mangled by nested quoting.
+
+        curl -s -G http://prom/api/v1/query --data-urlencode query@- <<< 'up == 0'
+
+    No data returned = inconclusive, never pass.
+
+5.  Alerts:
+
+        curl -s 'http://alertmanager/api/v2/alerts?silenced=false&inhibited=false&active=true'
+
+    A burst during the reboot window is expected — `NodeExporterDown{target=<node>}`
+    inhibits its dependents by design. What matters is that it clears. The
+    `Watchdog` alert must be present; its absence means the dead-man is broken.
+
+6.  On home-manager hosts (dev.ldn, rpi5.ldn) check **user** units too. A failed
+    home-manager activation freezes user services on the old generation, so the
+    system units can look perfect while nothing new was adopted.
+
+7.  Nothing enabled is sitting stopped. This is the failure mode a severed
+    switch leaves behind, and it is invisible to `--failed` and to
+    `is-system-running`:
+
+        ssh root@<node> 'systemctl list-unit-files --state=enabled --type=service \
+          --no-legend | awk "{print \$1}" | grep -v @ \
+          | xargs -r -I{} sh -c "systemctl is-active --quiet {} || echo {}" | sort'
+
+    Diff against the same command captured in Execute. Roughly 20 lines is
+    normal — oneshots that ran and exited — so only entries that are **new**
+    since the baseline count. Any of those is a fail: start it and find out
+    why it did not come up.
+
+Prove a failure from the host before calling it real: `systemctl is-active`,
+`ss -lntp`. A probe failing while the daemon is listening means the path is
+blocked, not the service.
+
+## Rollback
+
+Trigger: any Verify check fails, or two consecutive inconclusive results.
+
+    ssh root@<node> 'nixos-rebuild --rollback switch'
+    ssh root@<node> systemctl reboot     # if the rollback is itself self-severing
+
+Only 5 generations are kept (`boot.loader.*.configurationLimit` in
+`common/nix.nix`) and GC deletes older than 10 days — rollback goes no deeper.
+
+If a host is out of disk, `emergency-full-disk` is on every server
+(`profiles/server.nix`). It frees a 2 GB ballast file, vacuums the journal and
+collects garbage — but it also **deletes all but 2 system generations**, so
+running it destroys the rollback depth above. Roll back first if you still
+might need to, then reclaim.
+
+Cannot be rolled back: agenix key rotation, filesystem or dataset changes,
+anything that migrated data on disk. Those are forward-fix only.
+
+Physical access decides whether a bad reboot is recoverable. Ask which site a
+host is at rather than trusting a list here — the fleet moves:
+
+- **Leiden, NL** — hands available.
+- **Sandefjord, NO** — colo, provider console only.
+- **Sandefjord, NO** — Bassan's house.
+- **Tjodalyng, NO** — no hands, no console, no second host. Every reboot is
+  one-way.
+- **Oracle Cloud** — OCI web console.
+
+`.ldn` means Leiden. `oracldn` means Oracle London. Both are correct — do not
+"fix" either.
+
+## Escalate
+
+Ask before these, and only these. Everything else proceeds.
+
+- **Every reboot.** Execute step 3 does not run until the human says so.
+- Any finding from the Execute step-2 closure-diff list.
+- Deploying `dev.ldn` at all — it is the builder the rest of the fleet needs.
+- Deploying `core.tjoda` at all — no hands, no console, and it is the LAN
+  router. State the closure diff and wait.
+- Deploying `gigabuilder` — it bounces five guests, including CI.
+- A rollback that Rollback says cannot be rolled back.
+- garnix red on HEAD, or the x86 checks amber for over an hour.
+- Anything the wrapped `colmena` refused.
+
+## Notes
+
+- Deploy drift is `configurationRevision` diverging **between** hosts. All
+  hosts lagging master together is normal.
+- `root@<node>` works over Tailscale SSH; `sudo` as `kradalby` over ssh does
+  not (no askpass). Use root.
+- `nix flake check` and `colmena build` can outrun a tool-call timeout on a
+  cold cache. Run them in the workspace's shell pane and watch, not inline.
+- `rnb -m dev-ldn -- colmena apply …` forces the build onto a remote builder.
+  On dev.ldn `rnb` must run as root — `kradalby` is not a nix trusted-user there.

--- a/flake.nix
+++ b/flake.nix
@@ -728,11 +728,18 @@
             );
         };
 
+        # colmena here is wrapped with the deploy gate (git-ready): `apply`,
+        # `apply-local` and `upload-keys` refuse unless the repo is on master,
+        # clean, in sync with origin and fully pushed. It is deliberately not an
+        # overlay -- that would gate colmena for every consumer of this flake --
+        # and deliberately the only colmena on PATH, so the gate cannot be
+        # sidestepped by reaching for an unwrapped one.
         devShells.default = pkgs.mkShell {
           buildInputs = [
             treefmtEval.config.build.wrapper
             pkgs.unstable.prek
-            pkgs.colmena
+            (import ./pkgs/scripts/colmena-gate.nix { inherit pkgs; })
+            (import ./pkgs/scripts/git-ready.nix { inherit pkgs; })
             pkgs.webrepl_cli
           ];
         };

--- a/home/herdr.nix
+++ b/home/herdr.nix
@@ -14,6 +14,7 @@
 let
   herdr = "${pkgs.herdr}/bin/herdr";
   fish = "${pkgs.fish}/bin/fish";
+  ac = "${import ../pkgs/scripts/ac.nix { inherit pkgs; }}/bin/ac";
   # Panes are spawned by the server, so its env is theirs: profile bin for
   # claude/opencode/ac, plus the usual system paths.
   # /run/wrappers/bin first, per NixOS: without it `sudo` resolves to the
@@ -22,6 +23,32 @@ let
   darwinPath = "${config.home.profileDirectory}/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
 in
 {
+  options.my.herdr.permagents = lib.mkOption {
+    type = lib.types.listOf (
+      lib.types.submodule {
+        options = {
+          repo = lib.mkOption {
+            type = lib.types.str;
+            description = "Repository name under $GIT_ROOT (e.g. \"dotfiles\").";
+          };
+          role = lib.mkOption {
+            type = lib.types.str;
+            description = ''
+              Role to run, matching `<repo>/.agents/skills/<role>/SKILL.md`.
+            '';
+          };
+        };
+      }
+    );
+    default = [ ];
+    description = ''
+      Long-lived role sessions that should always exist in the herdr session.
+      Each becomes one workspace named "<repo>:<role>", reconciled once after
+      the server starts. Empty by default: only the machine you actually deploy
+      from wants these, and a host that merely runs herdr must not spawn them.
+    '';
+  };
+
   options.my.herdr.integrations = lib.mkOption {
     type = lib.types.listOf lib.types.str;
     default = [
@@ -60,6 +87,17 @@ in
       );
     }
 
+    (lib.mkIf (config.my.herdr.permagents != [ ]) {
+      # The reconcile below is a systemd user unit, so a darwin host would
+      # accept the option and silently spawn nothing.
+      assertions = [
+        {
+          assertion = pkgs.stdenv.hostPlatform.isLinux;
+          message = "my.herdr.permagents is Linux-only (systemd user unit)";
+        }
+      ];
+    })
+
     (lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
       systemd.user.services.herdr = {
         Unit.Description = "herdr — agent multiplexer server (session: ac)";
@@ -78,6 +116,34 @@ in
           OOMScoreAdjust = 100;
           # default_shell is unset (herdr falls back to $SHELL), so pin fish
           # here rather than managing a config.toml herdr also writes to.
+          Environment = [
+            "PATH=${linuxPath}"
+            "HOME=${config.home.homeDirectory}"
+            "SHELL=${fish}"
+          ];
+        };
+        Install.WantedBy = [ "default.target" ];
+      };
+
+      # Reconcile the declared role sessions once the server is up. A oneshot,
+      # not a supervised service: herdr owns the agent processes, so all this
+      # has to do is notice a missing workspace and create it. `ac permagent
+      # ensure` is idempotent, so re-running it on every login is a no-op.
+      # `|| true` per entry: one repo missing from disk must not stop the rest.
+      systemd.user.services.herdr-permagents = lib.mkIf (config.my.herdr.permagents != [ ]) {
+        Unit = {
+          Description = "herdr — ensure declared role sessions exist";
+          After = [ "herdr.service" ];
+          Requires = [ "herdr.service" ];
+        };
+        Service = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          ExecStart = pkgs.writeShellScript "herdr-permagents" (
+            lib.concatMapStringsSep "\n" (
+              a: "${ac} permagent ensure ${lib.escapeShellArg a.repo} ${lib.escapeShellArg a.role} || true"
+            ) config.my.herdr.permagents
+          );
           Environment = [
             "PATH=${linuxPath}"
             "HOME=${config.home.homeDirectory}"

--- a/machines/dev.ldn/default.nix
+++ b/machines/dev.ldn/default.nix
@@ -149,6 +149,21 @@ in
     ];
     my.atuin.enable = true; # personal account (shared with krair)
 
+    # This is the box the fleet is deployed from, so it is the one that wants
+    # a standing deploy agent per repo. Each is briefed from that repo's own
+    # .agents/skills/deploy/SKILL.md, so the rules live with the thing they
+    # deploy.
+    my.herdr.permagents = [
+      {
+        repo = "dotfiles";
+        role = "deploy";
+      }
+      {
+        repo = "sfiber";
+        role = "deploy";
+      }
+    ];
+
     programs.git.settings = {
       commit.gpgsign = true;
       gpg.format = "ssh";

--- a/pkgs/home-packages.nix
+++ b/pkgs/home-packages.nix
@@ -121,7 +121,6 @@ in
         nixfmt-rfc-style
         deadnix
         statix
-        colmena
         nix-init
         nurl
         ragenix

--- a/pkgs/scripts/ac.nix
+++ b/pkgs/scripts/ac.nix
@@ -2,13 +2,20 @@
 pkgs.writeShellApplication {
   name = "ac";
 
-  runtimeInputs = with pkgs; [
-    herdr
-    git
-    jq
-    coreutils
-    gnused
-  ];
+  runtimeInputs =
+    (with pkgs; [
+      herdr
+      git
+      jq
+      coreutils
+      gnused
+      # `hostname` is not part of coreutils; the remote-control name needs it and
+      # the boot-time permagent unit has no interactive profile to fall back on.
+      hostname
+    ])
+    # Role sessions report the gate's verdict in their opening briefing, and ac
+    # runs outside the dotfiles devShell, so it carries its own copy.
+    ++ [ (import ./git-ready.nix { inherit pkgs; }) ];
 
   text = builtins.readFile ./ac.sh;
 }

--- a/pkgs/scripts/ac.sh
+++ b/pkgs/scripts/ac.sh
@@ -12,6 +12,13 @@ DEFAULT_AGENT="claude"
 # Everything below drives that session over herdr's socket API.
 HERDR_SESSION="${HERDR_SESSION:-ac}"
 
+# A role session pins one long-lived agent to one repo for one job (deploy
+# today, others later). It always opens the repo's main worktree -- never a
+# branch worktree -- and its display name is "<repo>:<role>". A colon, not a
+# slash, because the label parser below splits repo from branch on the first
+# '/' and would read the role as a branch.
+ROLE=""
+
 # --- helpers ---
 
 die() {
@@ -26,8 +33,9 @@ h() {
 }
 
 sanitize() {
-  # Slashes are illegal in herdr agent names; branch names contain them.
-  echo "$1" | tr '/' '-'
+  # Slashes and colons are illegal in herdr agent names; branch names carry
+  # the first, role sessions the second.
+  echo "$1" | tr '/:' '--'
 }
 
 # agent_name maps a display name to a legal herdr agent handle:
@@ -43,10 +51,16 @@ agent_name() {
   printf '%s\n' "${n:0:32}"
 }
 
-# display: human name for a session — "repo/branch" or just "repo".
+# display: human name for a session — "repo:role", "repo/branch", or "repo".
 display() {
   local repo="$1" branch="$2"
-  if [[ -n "$branch" ]]; then echo "$repo/$branch"; else echo "$repo"; fi
+  if [[ -n "$ROLE" ]]; then
+    echo "$repo:$ROLE"
+  elif [[ -n "$branch" ]]; then
+    echo "$repo/$branch"
+  else
+    echo "$repo"
+  fi
 }
 
 agent_label() {
@@ -266,8 +280,7 @@ create_session() {
     argv=(--dangerously-skip-permissions)
     if [[ "${AC_REMOTE_CONTROL:-1}" == "1" ]]; then
       local rc_name
-      rc_name="$(hostname -s)-${repo}"
-      [[ -n "$branch" ]] && rc_name="${rc_name}-$(sanitize "$branch")"
+      rc_name="$(hostname -s)-$(sanitize "$(display "$repo" "$branch")")"
       argv+=(--remote-control "$rc_name")
     fi
   fi
@@ -278,7 +291,37 @@ create_session() {
     echo "warning: $agent in $pane did not report ready — check the pane" >&2
   fi
 
+  [[ -z "$ROLE" ]] || bootstrap_role "$pane" "$repo" "$dir"
+
   echo "$pane"
+}
+
+# bootstrap_role hands the agent its job the moment it is interactive. Sent as
+# a prompt rather than a per-agent launch flag because `agent prompt` is the one
+# injection point every agent kind shares — claude, codex and opencode alike —
+# and because it names the skill file explicitly, so the load is deterministic
+# instead of depending on a description matching.
+bootstrap_role() {
+  local pane="$1" repo="$2" dir="$3"
+  local skill=".agents/skills/$ROLE/SKILL.md" ready
+
+  if [[ ! -f "$dir/$skill" ]]; then
+    echo "warning: $repo has no $skill — starting the session unbriefed" >&2
+    return 0
+  fi
+
+  # The gate's verdict travels in the prompt rather than blocking creation: a
+  # session that says "main is 65 behind, fix me" beats a missing session.
+  if ! ready=$(git-ready "$dir" 2>&1); then
+    ready="FAILED — $ready"
+  fi
+
+  h agent prompt "$pane" "You are the $ROLE agent for $repo on $(hostname -s).
+Read $skill in this repo now and follow it.
+git-ready: $ready
+Change nothing until I say so. First report what a run would do, and anything
+already broken." >/dev/null ||
+    echo "warning: bootstrap prompt not delivered to $pane" >&2
 }
 
 # attach_herd hands off to the herdr TUI so `ac`/`ac ls` land you in the one
@@ -313,6 +356,9 @@ attach_workspace() {
 
 cmd_create_or_attach() {
   local repo="$1" branch="${2:-}" agent="${3:-$DEFAULT_AGENT}"
+
+  # A role plus a branch would be two different jobs sharing one name.
+  [[ -z "$ROLE" || -z "$branch" ]] || die "--role takes no branch"
 
   local dir
   if [[ -n "$branch" ]]; then
@@ -357,6 +403,25 @@ cmd_spawn() {
 
   create_session "$dir" "$agent" "$repo" "$branch" >/dev/null
   echo "spawned: $(display "$repo" "$branch")"
+}
+
+cmd_permagent() {
+  # `ensure <repo> <role>`: create the role session if missing, touch nothing
+  # if it is already there, never attach. Idempotent, so the boot-time unit can
+  # just run it once per declared permagent.
+  local action="$1" repo="$2" role="$3"
+  [[ "$action" == "ensure" ]] || die "usage: ac permagent ensure <repo> <role>"
+  ROLE="$role"
+
+  ensure_server
+
+  if [[ -n "$(find_workspace "$repo" "")" ]]; then
+    echo "present: $(display "$repo" "")"
+    return 0
+  fi
+
+  create_session "$(find_main_worktree "$repo")" "$DEFAULT_AGENT" "$repo" "" >/dev/null
+  echo "created: $(display "$repo" "")"
 }
 
 # workdir_of echoes the real cwd of a workspace (its root pane), so ac-web can
@@ -500,7 +565,8 @@ cmd_remove() {
 cmd_selftest() {
   local s n fails=0
   for s in "headscale/kradalby/go127" "TubeLogger2000" "dotfiles" \
-    "2000only" "1234" "sfiber/planet-olt" "a.b" "x/$(printf 'y%.0s' {1..60})"; do
+    "2000only" "1234" "sfiber/planet-olt" "a.b" "x/$(printf 'y%.0s' {1..60})" \
+    "dotfiles:deploy" "sfiber:deploy" "TubeLogger2000:deploy"; do
     n=$(agent_name "$s")
     if [[ "$n" =~ ^[a-z][a-z0-9_-]{0,31}$ ]]; then
       echo "ok   $s -> $n"
@@ -527,6 +593,8 @@ Commands:
   ls --porcelain         Tab-separated listing (for ac-web)
   spawn <repo> [branch]  Create a detached workspace without attaching (for ac-web)
   rm <workspace|name>    Gracefully stop the agent and close the workspace
+  permagent ensure <repo> <role>
+                         Create the role session if missing; no-op if present
   selftest               Check agent-name mangling against herdr's grammar
   help                   Show this help
 
@@ -534,6 +602,18 @@ Flags:
   -o, --opencode         Use opencode instead of claude
   -c, --claude           Use claude (default)
   -x, --codex            Use codex
+  -r, --role <name>      Open the repo's long-lived <name> session instead of a
+                         coding session (see "Role sessions" below)
+
+Role sessions:
+  `ac -r deploy dotfiles` opens one durable agent pinned to a repo and a job.
+  It always uses the repo's main worktree, is named "<repo>:<role>", and is
+  briefed on start from <repo>/.agents/skills/<role>/SKILL.md — the Agent
+  Skills path Codex and OpenCode already discover. The briefing carries the
+  `git-ready` verdict (default branch, clean, in sync, nothing unpushed), so
+  the agent knows the repo's state before it does anything. A failing verdict
+  does not block the session: the deploy commands are gated themselves, and a
+  session that can tell you what is wrong beats a missing one.
 
 To switch or split sessions interactively, attach the herd with `herdr` (or
 `herdr --session ac`) and use its TUI — that's the single overview.
@@ -553,7 +633,8 @@ Examples:
   ac headscale kradalby/3049     claude on ~/worktrees/headscale/kradalby/3049
   ac headscale kradalby/new      prompts to create branch from upstream/main
   ac sfiber planet-olt -o        opencode on ~/worktrees/sfiber/planet-olt
-  ac rm headscale/kradalby/3049  Gracefully close that workspace
+  ac -r deploy dotfiles          the durable "dotfiles:deploy" session
+  ac rm dotfiles:deploy          Gracefully close that workspace
 
 Each workspace opens two herdr panes in one tab:
   agent   Coding agent (claude/opencode/codex), launched directly (argv, no shell)
@@ -587,6 +668,11 @@ main() {
       -x | --codex)
         agent="codex"
         shift
+        ;;
+      -r | --role)
+        [[ $# -ge 2 ]] || die "--role needs a name"
+        ROLE="$2"
+        shift 2
         ;;
       -p | --porcelain)
         porcelain=1
@@ -635,6 +721,10 @@ main() {
     spawn)
       [[ ${#args[@]} -ge 2 ]] || die "usage: ac spawn <repo> [branch]"
       cmd_spawn "${args[1]}" "${args[2]:-}" "$agent"
+      ;;
+    permagent)
+      [[ ${#args[@]} -ge 4 ]] || die "usage: ac permagent ensure <repo> <role>"
+      cmd_permagent "${args[1]}" "${args[2]}" "${args[3]}"
       ;;
     rm | remove | kill)
       [[ ${#args[@]} -ge 2 ]] || die "usage: ac rm <workspace|name>"

--- a/pkgs/scripts/colmena-gate.nix
+++ b/pkgs/scripts/colmena-gate.nix
@@ -1,0 +1,19 @@
+# colmena, with the deploy gate wrapped around it. symlinkJoin rather than a
+# hand-written replacement so colmena's man pages and shell completions survive.
+{ pkgs, ... }:
+let
+  gate = pkgs.writeShellApplication {
+    name = "colmena-gate";
+    runtimeInputs = [ (import ./git-ready.nix { inherit pkgs; }) ];
+    text = builtins.readFile ./colmena-gate.sh;
+  };
+in
+pkgs.symlinkJoin {
+  name = "colmena-gated";
+  paths = [ pkgs.colmena ];
+  nativeBuildInputs = [ pkgs.makeWrapper ];
+  postBuild = ''
+    wrapProgram $out/bin/colmena \
+      --run '${gate}/bin/colmena-gate "$@" || exit 1'
+  '';
+}

--- a/pkgs/scripts/colmena-gate.sh
+++ b/pkgs/scripts/colmena-gate.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# colmena-gate — the check that runs before colmena's mutating subcommands.
+# Wrapped onto colmena in the devShell, so `colmena apply` cannot be reached
+# without it. Receives colmena's own argv; exit 0 lets the run proceed.
+
+set -euo pipefail
+
+# Match the subcommand anywhere in argv rather than "the first non-flag":
+# global options take values (`colmena -f ./flake.nix apply`), so positional
+# scanning would read the value as the subcommand. An unrelated argument that
+# happens to equal a subcommand name gates a run that did not need it — this
+# errs closed, which is the right direction for a gate.
+sub=""
+for arg in "$@"; do
+  case "$arg" in
+    apply | apply-local | upload-keys)
+      sub="$arg"
+      break
+      ;;
+  esac
+done
+
+# build, eval, repl, exec, nix-info and --help are never gated: build is how
+# you preview a dirty tree, and exec is how you verify a host afterwards.
+[[ -n "$sub" ]] || exit 0
+
+if git-ready; then
+  exit 0
+fi
+
+# Break-glass. A human at a terminal can override mid-incident; an agent
+# cannot, because its shell has no TTY. Deliberately not an environment
+# variable — one an agent can set is not a gate.
+if [[ -t 0 && -t 1 ]]; then
+  read -r -p "colmena $sub anyway? type 'yes' to override: " answer
+  if [[ "$answer" == "yes" ]]; then
+    exit 0
+  fi
+fi
+
+echo "colmena $sub refused: the repo is not in a deployable state." >&2
+exit 1

--- a/pkgs/scripts/git-ready.nix
+++ b/pkgs/scripts/git-ready.nix
@@ -1,0 +1,12 @@
+{ pkgs, ... }:
+pkgs.writeShellApplication {
+  name = "git-ready";
+
+  runtimeInputs = with pkgs; [
+    git
+    gawk
+    coreutils
+  ];
+
+  text = builtins.readFile ./git-ready.sh;
+}

--- a/pkgs/scripts/git-ready.sh
+++ b/pkgs/scripts/git-ready.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# git-ready — assert a repo is safe to deploy from: on its default branch,
+# clean, in sync with origin, nothing unpushed. One line of output either way.
+#
+# Exit 0  every check passed
+# Exit 1  a check failed, or the repo could not be evaluated
+#
+# Usage: git-ready [--no-fetch] [dir]
+#        git-ready --selftest
+
+set -euo pipefail
+
+dir="."
+fetch=1
+
+fail() {
+  echo "git-ready: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'USAGE'
+git-ready — assert a repo is safe to deploy from.
+
+Checks the repo is on its default branch, has a clean tree, is in sync with
+origin, and has nothing unpushed (commits or tags).
+
+Usage: git-ready [--no-fetch] [dir]
+       git-ready --selftest
+
+Exit 0 = every check passed. Exit 1 = a check failed, or the repo could not be
+evaluated. Never mutates the repo and never pushes.
+USAGE
+}
+
+# g: git in the target repo. Named g, not git, so the calls read as deliberate
+# and shellcheck does not have to reason about a shadowed builtin name.
+g() { command git -C "$dir" "$@"; }
+
+ready() {
+  g rev-parse --git-dir >/dev/null 2>&1 || fail "not a git repository: $dir"
+
+  # symbolic-ref exits non-zero on a detached HEAD. `branch --show-current`
+  # would print nothing and exit 0, reporting a blank branch name instead.
+  local branch
+  branch=$(g symbolic-ref --quiet --short HEAD) || fail "detached HEAD"
+
+  # The local symref is authoritative; ls-remote covers a clone that never ran
+  # `git remote set-head`.
+  local default
+  default=$(g symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  default="${default#origin/}"
+  if [[ -z "$default" ]]; then
+    default=$(g ls-remote --symref origin HEAD 2>/dev/null |
+      awk '$1 == "ref:" { sub("refs/heads/", "", $2); print $2; exit }' || true)
+  fi
+  [[ -n "$default" ]] ||
+    fail "cannot determine origin's default branch (try: git remote set-head origin --auto)"
+
+  # Compare branch NAMES. @{u} is not the test: a worktree can track
+  # origin/<default> while sitting on a feature branch.
+  [[ "$branch" == "$default" ]] || fail "on '$branch', not '$default'"
+
+  # -unormal defeats status.showUntrackedFiles=no and --ignore-submodules=none
+  # defeats diff.ignoreSubmodules; either setting otherwise reads dirty as clean.
+  local dirty
+  dirty=$(g status --porcelain -unormal --ignore-submodules=none)
+  if [[ -n "$dirty" ]]; then
+    echo "$dirty" >&2
+    fail "working tree not clean"
+  fi
+
+  # --prune only. --prune-tags deletes local-only tags, which a check must not do.
+  if [[ "$fetch" == 1 ]]; then
+    g fetch --quiet --prune origin || fail "git fetch failed"
+  fi
+
+  g rev-parse --verify --quiet "refs/remotes/origin/$default" >/dev/null ||
+    fail "no refs/remotes/origin/$default — fetch first"
+
+  local behind ahead
+  read -r behind ahead < <(g rev-list --left-right --count "refs/remotes/origin/$default...HEAD")
+  [[ "$ahead" == 0 ]] || fail "$ahead unpushed commit(s) on $branch"
+  [[ "$behind" == 0 ]] || fail "$behind commit(s) behind origin/$default"
+
+  # Tags travel separately from commits, so "everything pushed" has to check
+  # them too. --refs drops the peeled ^{} rows so the object names compare.
+  local local_tags remote_tags unpushed
+  local_tags=$(g for-each-ref --format='%(refname:short) %(objectname)' refs/tags | sort)
+  if [[ -n "$local_tags" ]]; then
+    remote_tags=$(g ls-remote --tags --refs origin 2>/dev/null |
+      awk '{ sub("refs/tags/", "", $2); print $2, $1 }' | sort || true)
+    unpushed=$(comm -23 <(echo "$local_tags") <(echo "$remote_tags") || true)
+    if [[ -n "$unpushed" ]]; then
+      fail "unpushed or moved tag(s): $(awk '{ print $1 }' <<<"$unpushed" | tr '\n' ' ')"
+    fi
+  fi
+
+  echo "git-ready: ok $branch $(g rev-parse --short HEAD)"
+}
+
+# selftest builds throwaway repos and asserts each verdict. This script is a
+# deploy gate, so a silent regression here is a silent loss of the gate.
+selftest() {
+  local root fails=0
+  root=$(mktemp -d)
+  # shellcheck disable=SC2064 # expand root now; the trap outlives the local
+  trap "rm -rf '$root'" EXIT
+
+  local remote="$root/remote.git" work="$root/work" other="$root/other"
+  command git init --quiet --bare "$remote"
+  command git -C "$remote" symbolic-ref HEAD refs/heads/main
+  command git clone --quiet "$remote" "$work" 2>/dev/null
+  command git -C "$work" config user.email t@example.invalid
+  command git -C "$work" config user.name test
+  echo a >"$work/a"
+  command git -C "$work" add a
+  command git -C "$work" commit --quiet -m init
+  command git -C "$work" push --quiet -u origin main
+  command git -C "$work" remote set-head origin --auto >/dev/null
+
+  # check <wanted exit> <label>. Runs ready() in a subshell rather than
+  # re-execing $0, so the test does not depend on the file being executable.
+  check() {
+    local want="$1" label="$2" rc=0
+    (
+      dir="$work"
+      fetch=0
+      ready
+    ) >/dev/null 2>&1 || rc=$?
+    if [[ "$rc" == "$want" ]]; then
+      echo "ok   $label"
+    else
+      echo "FAIL $label (exit $rc, wanted $want)" >&2
+      fails=$((fails + 1))
+    fi
+  }
+
+  check 0 "clean, on default branch, in sync"
+
+  echo dirt >"$work/untracked"
+  check 1 "untracked file counts as dirty"
+  rm "$work/untracked"
+
+  command git -C "$work" checkout --quiet -b feature
+  check 1 "not on the default branch"
+  command git -C "$work" checkout --quiet main
+
+  echo b >"$work/b"
+  command git -C "$work" add b
+  command git -C "$work" commit --quiet -m ahead
+  check 1 "unpushed commit"
+  command git -C "$work" reset --quiet --hard HEAD~1
+
+  command git -C "$work" tag v1
+  check 1 "unpushed tag"
+  command git -C "$work" tag -d v1 >/dev/null
+
+  check 0 "back to clean"
+
+  # Behind, from a second clone. Last: it leaves $work behind origin.
+  command git clone --quiet "$remote" "$other" 2>/dev/null
+  command git -C "$other" config user.email t@example.invalid
+  command git -C "$other" config user.name test
+  echo c >"$other/c"
+  command git -C "$other" add c
+  command git -C "$other" commit --quiet -m remote-ahead
+  command git -C "$other" push --quiet origin main
+  command git -C "$work" fetch --quiet origin
+  check 1 "behind origin"
+
+  [[ "$fails" == 0 ]] || fail "$fails selftest case(s) failed"
+  echo "selftest passed"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-fetch)
+      fetch=0
+      shift
+      ;;
+    --selftest)
+      selftest
+      exit 0
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    -*) fail "unknown flag: $1" ;;
+    *)
+      dir="$1"
+      shift
+      ;;
+  esac
+done
+
+ready

--- a/rc/claude/commands/kra-triage.md
+++ b/rc/claude/commands/kra-triage.md
@@ -6,18 +6,20 @@ Triage the fleet. Report only what needs a human. Be brief.
 
 ## Access
 
-Prometheus/Alertmanager live on `core-oracldn` and are **not** reachable
-from laptops or dev boxes — the tailnet ACL denies `tag:monitoring` ports
-and the VIP names (`prom`, `alertmanager`) do not resolve off-host. Go via
-SSH:
+Prometheus/Alertmanager are tailnet VIP services on **tcp:80/443** — reach
+them by short name, no ssh hop:
 
 ```sh
-ssh core-oracldn 'curl -s "localhost:9093/api/v2/alerts?silenced=false&inhibited=false&active=true"'
-ssh core-oracldn 'curl -s -G localhost:9090/api/v1/query --data-urlencode query@-' <<< 'up == 0'
+curl -s 'http://alertmanager/api/v2/alerts?silenced=false&inhibited=false&active=true'
+curl -s -G http://prom/api/v1/query --data-urlencode query@- <<< 'up == 0'
 ```
 
 Feed PromQL on stdin (`query@-`). Inline `--data-urlencode "query=..."`
-gets mangled by nested shell quoting over SSH.
+gets mangled by nested shell quoting.
+
+If a name does not resolve, that is the ACL, not DNS: an ungranted VIP is
+absent from MagicDNS entirely. The grant is in
+`~/git/infrastructure/tailscale/policy.hujson`.
 
 ## Steps
 


### PR DESCRIPTION
A deploy is the one job where a fresh agent every time is worst: the rules are
per-repo, the traps are learned from incidents, and the context is worth
keeping. `ac -r deploy dotfiles` opens one durable session pinned to a repo and
a job, briefed at start from that repo's own
`.agents/skills/deploy/SKILL.md` — so the rules get reviewed in the same PR as
the deploy change that invalidates them.

The gate is the part worth arguing about. A check the agent must *remember* to
run is prose, not enforcement, so `colmena` in the devShell **is** the gated
one: `apply`, `apply-local` and `upload-keys` refuse unless `git-ready` passes
(default branch, clean, in sync, nothing unpushed). `build` and `exec` stay
open, since previewing and verifying both need a dirty tree. Devshell only — an
overlay would gate colmena on every host — and `colmena` is dropped from
`home-packages.nix` so exactly one exists. Break-glass needs a TTY on stdin
*and* stdout; an env var an agent can set is not a gate. `nix run
nixpkgs#colmena` still bypasses it, and that is accepted: the point is that the
normal name is gated, not that bypass is impossible.

A skill rather than an agent spec, because `.claude/agents/*.md`,
`.opencode/agent/*.md` and `.codex/agents/*.toml` are three incompatible
schemas while Agent Skills is the shared standard. Skills normally load on a
fuzzy description match, which is wrong for a dedicated session, so `ac` names
the file outright via `herdr agent prompt` — the one injection point every
agent kind shares, so scoping this to Claude Code today costs nothing later.

`my.herdr.permagents` reconciles the declared sessions once herdr is up. Empty
by default: only the box the fleet is deployed from wants them.

Verified: `git-ready --selftest` (7 cases), the wrapper refusing
`apply`/`apply-local` while `build` and `--help` pass, `ac permagent ensure`
idempotent with the workspace, handle and listings correct, and the briefing
landing. Not verified: conversation resume across a herdr restart — restarting
the server would kill every live pane in the shared `ac` session.

Companion PR in `sfiber` adds the same four checks to `release-tag` and its own
deploy skill.

> Generated with the help of an AI assistant