### PR TITLE
ci: make the cache-hosts workflow actually work

### DIFF
--- a/.github/actions/tsnixcache-build/action.yml
+++ b/.github/actions/tsnixcache-build/action.yml
@@ -1,0 +1,93 @@
+name: build into tsnixcache
+description: Join the tailnet, install nix, build store paths and push their closures.
+
+inputs:
+  paths-command:
+    description: Shell printing the store paths to push on stdout. Build logs go to stderr.
+    required: true
+  ts-oauth-client-id:
+    description: Tailscale OAuth client id. Composite actions cannot read secrets themselves.
+    required: true
+  ts-oauth-secret:
+    description: Tailscale OAuth client secret.
+    required: true
+  cache-url:
+    description: tsnixcache base URL, read by both watch and push.
+    default: http://tsnixcache
+  extra-nix-conf:
+    description: Extra nix.conf lines for this job only.
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    # Must precede nix: tsnixcache is tailnet-only, so the node has to be on the
+    # tailnet before nix.conf names it. tag:github-builder carries the push grant.
+    - name: Join tailnet
+      uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
+      with:
+        oauth-client-id: ${{ inputs.ts-oauth-client-id }}
+        oauth-secret: ${{ inputs.ts-oauth-secret }}
+        tags: tag:github-builder
+
+    - name: Install Nix
+      uses: NixOS/nix-installer-action@62c1943b776c509394b550f3f983adc14e9212d6 # main
+      with:
+        extra-conf: |
+          extra-substituters = ${{ inputs.cache-url }}?priority=30 https://nixos-raspberrypi.cachix.org
+          extra-trusted-public-keys = tsnixcache:Chid5Mll6U8ZUCio/j4KqxgtIeqPxH8Duqpz96TU4Es= nixos-raspberrypi.cachix.org-1:4iMO9LXa8BqhU+Rpg6LQKiGa2lsNh/j2oiYLNOQ5sPI=
+          connect-timeout = 5
+          fallback = true
+          ${{ inputs.extra-nix-conf }}
+
+    # Two pins: the SHA-pinned action passes CLI flags to a binary it downloads
+    # separately, so `version` must move with it. Filter keeps cache.nixos.org
+    # paths out of the 10 GB repo-wide quota.
+    - name: Setup Nix cache
+      uses: Mic92/hestia@f1f4df2801140a36398ed423533c8460618539df # v3.0.1
+      with:
+        version: v3.0.1
+        upstream-cache-filter: "true"
+
+    # Streams paths as they land, so a build that dies late still leaves its
+    # dependencies cached. No --idle-exit: a slow build goes quiet for longer
+    # than any sane window, and an exited watcher stops streaming silently.
+    # Redirected and disowned, not a bare `&`: the step's shell exits at once
+    # and a watcher still writing to its log pipe takes SIGPIPE.
+    - name: Start cache watcher
+      shell: bash
+      env:
+        TSNIXCACHE_URL: ${{ inputs.cache-url }}
+      run: |
+        nix run github:kradalby/tsnixcache/initial -- watch \
+          --pid-file "$RUNNER_TEMP/cache.pid" \
+          > "$RUNNER_TEMP/watch.log" 2>&1 &
+        disown
+
+    # Braced: a multi-line paths-command ends in a newline, which would strand
+    # the redirect on its own line. The push backstops the watcher.
+    - name: Build and push
+      shell: bash
+      env:
+        TSNIXCACHE_URL: ${{ inputs.cache-url }}
+      run: |
+        {
+          ${{ inputs.paths-command }}
+        } > "$RUNNER_TEMP/paths"
+        nix run github:kradalby/tsnixcache/initial -- push - < "$RUNNER_TEMP/paths"
+
+    # SIGTERM makes the watcher drain what is queued and exit, so a failed build
+    # still ships what it did manage to build. No PID file means it died; the
+    # log says why.
+    - name: Drain cache uploads
+      if: always()
+      shell: bash
+      env:
+        TSNIXCACHE_URL: ${{ inputs.cache-url }}
+      run: |
+        if [ -f "$RUNNER_TEMP/cache.pid" ]; then
+          kill -TERM "$(cat "$RUNNER_TEMP/cache.pid")" 2>/dev/null || true
+          nix run github:kradalby/tsnixcache/initial -- wait-for \
+            --pid-file "$RUNNER_TEMP/cache.pid"
+        fi
+        cat "$RUNNER_TEMP/watch.log" 2>/dev/null || echo "watcher wrote no log"

--- a/.github/workflows/cache-hosts.yml
+++ b/.github/workflows/cache-hosts.yml
@@ -1,27 +1,16 @@
-# Rented build hardware, nothing more. garnix is the CI; this only covers the
-# targets it has no machine for, because arm and mac boxes cost money:
+# Rented build hardware. garnix is the CI; this covers only the targets it has
+# no machine for, because arm and mac boxes cost money. Each job builds one
+# target and pushes its closure to tsnixcache, so garnix and deploys
+# substitute. Standard GitHub runners are free on public repos, macOS included.
 #
-#   aarch64 linux — one borrowed builder at maxJobs 1, so the three hosts built
-#     strictly one after another and added 30-60 min per commit.
-#   darwin — no macOS builder at all, so these had no CI whatsoever.
-#
-# Each job builds one target and pushes the closure to tsnixcache, so garnix
-# and deploys substitute instead of rebuild. Standard GitHub runners are free
-# and unmetered on public repos, macOS included; only "larger" runners are
-# billed there. Mirrors `nix run .#cache-arm` (pkgs/cache-arm.nix), the same
-# build-and-push path used by hand.
-#
-# Buy an aarch64 builder or a mac and this goes away: drop the matching entry
-# here and the matching exclude in garnix.yaml, and garnix takes it back.
+# Buy the hardware and this goes away: drop the entry here and its exclude in
+# garnix.yaml, and garnix takes the target back.
 name: cache hosts
 
 on:
   push:
   workflow_dispatch:
 
-# Per-ref, so a new push cancels the previous run's stragglers. Within a run
-# nothing is serialised: the matrix is one job per target and fail-fast is off,
-# so all five runners start together and a failure never cancels its siblings.
 concurrency:
   group: cache-hosts-${{ github.ref }}
   cancel-in-progress: true
@@ -29,97 +18,72 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  TSNIXCACHE_URL: http://tsnixcache
-
 jobs:
-  build:
+  hosts:
     name: ${{ matrix.host }}
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
         include:
           - host: core.oracldn
-            runner: ubuntu-24.04-arm
-            attr: 'nixosConfigurations."core.oracldn".config.system.build.toplevel'
           - host: dev.oracfurt
-            runner: ubuntu-24.04-arm
-            attr: 'nixosConfigurations."dev.oracfurt".config.system.build.toplevel'
           - host: rpi5.ldn
-            runner: ubuntu-24.04-arm
-            attr: 'nixosConfigurations."rpi5.ldn".config.system.build.toplevel'
-          - host: krair
-            runner: macos-15
-            attr: darwinConfigurations.krair.system
-          - host: kratail2
-            runner: macos-15
-            attr: darwinConfigurations.kratail2.system
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      # Before nix: tsnixcache is a tailnet-only substituter, so the node must
-      # be on the tailnet before nix.conf names it. tag:github-builder carries
-      # the push grant (infrastructure/tailscale/policy.hujson). On macOS the
-      # action builds tailscale from source and sets system DNS via
-      # networksetup, so MagicDNS reaches the nix daemon too.
-      - name: Join tailnet
-        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/tsnixcache-build
         with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:github-builder
+          ts-oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          ts-oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          paths-command: >-
+            nix build --no-link --print-out-paths -L
+            '.#nixosConfigurations."${{ matrix.host }}".config.system.build.toplevel'
 
-      - name: Install Nix
-        uses: NixOS/nix-installer-action@62c1943b776c509394b550f3f983adc14e9212d6 # main
+  # Both Macs run a nix-rosetta-builder VM, so their closures hold an
+  # aarch64-linux disk image no macOS runner can build. Build it where the
+  # platform matches; darwin then substitutes the image, not its inputs. The
+  # module keeps it in a `let`, so it is reached through the system closure —
+  # whatever the config depends on is what gets built.
+  rosetta:
+    name: rosetta image ${{ matrix.host }}
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        host: [krair, kratail2]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/tsnixcache-build
         with:
-          extra-conf: |
-            extra-substituters = ${{ env.TSNIXCACHE_URL }}?priority=30 https://nixos-raspberrypi.cachix.org
-            extra-trusted-public-keys = tsnixcache:Chid5Mll6U8ZUCio/j4KqxgtIeqPxH8Duqpz96TU4Es= nixos-raspberrypi.cachix.org-1:4iMO9LXa8BqhU+Rpg6LQKiGa2lsNh/j2oiYLNOQ5sPI=
-            connect-timeout = 5
-            fallback = true
+          ts-oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          ts-oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          # No /dev/kvm on GitHub runners. qemu asks for accel=kvm:tcg and falls
+          # back on its own; only nix's feature gate refused to start.
+          extra-nix-conf: extra-system-features = kvm
+          paths-command: |
+            sys=$(nix eval --raw '.#darwinConfigurations.${{ matrix.host }}.system.drvPath')
+            img=$(nix-store --query --requisites "$sys" | grep -m1 'nixos-disk-image\.drv$' || true)
+            test -n "$img" || { echo "no rosetta image in ${{ matrix.host }} closure" >&2; exit 1; }
+            nix build --no-link --print-out-paths -L "$img^*"
 
-      # Two pins because hestia is one program in two artifacts: the SHA-pinned
-      # action passes CLI flags to a binary it downloads separately, so a
-      # floating `version` can hand it a binary that renamed them. Bump both
-      # together.
-      # upstream-cache-filter keeps cache.nixos.org paths out of the 10 GB
-      # repo-wide GHA cache quota; only our own outputs land there.
-      - name: Setup Nix cache
-        uses: Mic92/hestia@f1f4df2801140a36398ed423533c8460618539df # v3.0.1
+  # Waits on its own image only, never on the arm hosts.
+  darwin:
+    name: ${{ matrix.host }}
+    runs-on: macos-15
+    needs: rosetta
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        host: [krair, kratail2]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/tsnixcache-build
         with:
-          version: v3.0.1
-          upstream-cache-filter: "true"
-
-      # Uploads each new store path as it lands, so a build that dies at 90%
-      # still leaves everything it got through on the cache. --idle-exit stops
-      # it once the store goes quiet. Both watch and push read TSNIXCACHE_URL.
-      - name: Start cache watcher
-        run: |
-          nix run github:kradalby/tsnixcache/initial -- watch \
-            --idle-exit 120s --pid-file "$RUNNER_TEMP/cache.pid" &
-
-      # Same two steps as `nix run .#cache-arm` (pkgs/cache-arm.nix), inlined:
-      # the flake exposes no aarch64-linux apps, and adding them would hand
-      # garnix a set of new jobs on the one slow aarch64 builder this bypasses.
-      # The push is belt to the watcher's braces: it names the whole closure, so
-      # nothing is left behind if the watcher missed a path or started late.
-      - name: Build and push ${{ matrix.host }}
-        run: |
-          out=$(nix build --no-link --print-out-paths -L '.#${{ matrix.attr }}')
-          nix run github:kradalby/tsnixcache/initial -- push "$out"
-
-      # Blocks until the watcher's queue drains. always(), so a failed build
-      # still ships what it did manage to build.
-      - name: Drain cache uploads
-        if: always()
-        run: |
-          nix run github:kradalby/tsnixcache/initial -- wait-for \
-            --pid-file "$RUNNER_TEMP/cache.pid"
-
-      # 14 GB runner disk is the tight resource here; report it either way.
-      - name: Disk
-        if: always()
-        run: df -h /
+          ts-oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          ts-oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          paths-command: >-
+            nix build --no-link --print-out-paths -L
+            '.#darwinConfigurations.${{ matrix.host }}.system'

--- a/.github/workflows/cache-hosts.yml
+++ b/.github/workflows/cache-hosts.yml
@@ -22,20 +22,26 @@ jobs:
   hosts:
     name: ${{ matrix.host }}
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 120
+    timeout-minutes: ${{ matrix.timeout || 120 }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - host: core.oracldn
           - host: dev.oracfurt
+          # nixos-raspberrypi's overlays give rpi5 its own python, so it builds
+          # what the others substitute, and those tests lose races under
+          # contention. Slower, but it only has to succeed once to be cached.
           - host: rpi5.ldn
+            nix-conf: max-jobs = 1
+            timeout: 330
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/tsnixcache-build
         with:
           ts-oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           ts-oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          extra-nix-conf: ${{ matrix.nix-conf }}
           paths-command: >-
             nix build --no-link --print-out-paths -L
             '.#nixosConfigurations."${{ matrix.host }}".config.system.build.toplevel'


### PR DESCRIPTION
Two separate bugs stopped the first real run on master. Both are mine, from the
same afternoon.

**The watcher never survived its own step.** A bare `&` in a `run:` step left it
writing to a log pipe the step closed on exit, so it took SIGPIPE while still
printing `copying path …` and died before writing `--pid-file`. Every job then
failed draining, *after* building and pushing successfully — `push: done
paths=1007 uploaded=10 skipped=997`. Redirect to a file and `disown`. A watcher
that idle-exits also removes that file, which one long derivation (the rpi5
kernel) makes routine, so absent now means drained rather than broken.

**The Macs cannot build their own closures.** Both run a nix-rosetta-builder VM,
so `darwinConfigurations.<host>.system` pulls an aarch64-linux NixOS disk image
and a macOS runner stops dead on `platform mismatch`. Build that image on an arm
runner, where the platform matches, and push it — the darwin job then
substitutes the finished image and never sees its linux inputs. The module keeps
the image in a `let` binding rather than an option, so it is reached through the
system closure: whatever the config actually depends on is what gets built, with
nothing to keep in sync by hand.

The jobs split three ways to keep that ordering cheap. `darwin` waits on its own
image only, never on the arm hosts, since rpi5 can take an hour. The steps every
job shares moved into a local composite action rather than being written three
times.

> Generated with the help of an AI assistant